### PR TITLE
no_std support (with default-enabled "std" cargo feature)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ matrix:
     - env: RUST_TEST_THREADS=1 TARGET=powerpc-unknown-linux-gnu
     - env: RUST_TEST_THREADS=1 TARGET=powerpc64-unknown-linux-gnu
 
+    # Ensure crate compiles without default features (i.e. for no_std)
+    - env: EXTRA_ARGS="--no-default-features"
+      script: cargo build $EXTRA_ARGS
+
     # Serde implementation
     - env: EXTRA_ARGS="--features serde"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ exclude       = [
     "bench/**/*",
     "test/**/*"
 ]
-categories = ["network-programming", "data-structures"]
+categories = ["network-programming", "data-structures", "no-std"]
 
 [package.metadata.docs.rs]
 features = ["i128"]
 
 [dependencies]
 byteorder = "1.1.0"
-iovec = "0.1"
+iovec = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true }
 either = { version = "1.5", default-features = false, optional = true }
 
@@ -37,4 +37,6 @@ either = { version = "1.5", default-features = false, optional = true }
 serde_test = "1.0"
 
 [features]
+default = ["std"]
 i128 = ["byteorder/i128"]
+std = ["iovec"]

--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -1,4 +1,5 @@
 use {Buf, BufMut};
+#[cfg(feature = "iovec")]
 use iovec::IoVec;
 
 /// A `Chain` sequences two buffers.
@@ -177,6 +178,7 @@ impl<T, U> Buf for Chain<T, U>
         self.b.advance(cnt);
     }
 
+    #[cfg(feature = "iovec")]
     fn bytes_vec<'a>(&'a self, dst: &mut [&'a IoVec]) -> usize {
         let mut n = self.a.bytes_vec(dst);
         n += self.b.bytes_vec(&mut dst[n..]);
@@ -218,6 +220,7 @@ impl<T, U> BufMut for Chain<T, U>
         self.b.advance_mut(cnt);
     }
 
+    #[cfg(feature = "iovec")]
     unsafe fn bytes_vec_mut<'a>(&'a mut self, dst: &mut [&'a mut IoVec]) -> usize {
         let mut n = self.a.bytes_vec_mut(dst);
         n += self.b.bytes_vec_mut(&mut dst[n..]);

--- a/src/buf/from_buf.rs
+++ b/src/buf/from_buf.rs
@@ -1,4 +1,8 @@
-use {Buf, BufMut, IntoBuf, Bytes, BytesMut};
+use {IntoBuf};
+#[cfg(feature = "std")]
+use prelude::*;
+#[cfg(feature = "std")]
+use {Buf, BufMut, Bytes, BytesMut};
 
 /// Conversion from a [`Buf`]
 ///
@@ -86,6 +90,7 @@ pub trait FromBuf {
     fn from_buf<T>(buf: T) -> Self where T: IntoBuf;
 }
 
+#[cfg(feature = "std")]
 impl FromBuf for Vec<u8> {
     fn from_buf<T>(buf: T) -> Self
         where T: IntoBuf
@@ -97,6 +102,7 @@ impl FromBuf for Vec<u8> {
     }
 }
 
+#[cfg(feature = "std")]
 impl FromBuf for Bytes {
     fn from_buf<T>(buf: T) -> Self
         where T: IntoBuf
@@ -105,6 +111,7 @@ impl FromBuf for Bytes {
     }
 }
 
+#[cfg(feature = "std")]
 impl FromBuf for BytesMut {
     fn from_buf<T>(buf: T) -> Self
         where T: IntoBuf

--- a/src/buf/into_buf.rs
+++ b/src/buf/into_buf.rs
@@ -1,5 +1,8 @@
 use super::{Buf};
+#[cfg(feature = "std")]
+use prelude::*;
 
+#[cfg(feature = "std")]
 use std::io;
 
 /// Conversion into a `Buf`
@@ -55,6 +58,7 @@ impl<T: Buf> IntoBuf for T {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a [u8] {
     type Buf = io::Cursor<&'a [u8]>;
 
@@ -63,6 +67,7 @@ impl<'a> IntoBuf for &'a [u8] {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a mut [u8] {
     type Buf = io::Cursor<&'a mut [u8]>;
 
@@ -71,6 +76,7 @@ impl<'a> IntoBuf for &'a mut [u8] {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a str {
     type Buf = io::Cursor<&'a [u8]>;
 
@@ -79,6 +85,7 @@ impl<'a> IntoBuf for &'a str {
     }
 }
 
+#[cfg(feature = "std")]
 impl IntoBuf for Vec<u8> {
     type Buf = io::Cursor<Vec<u8>>;
 
@@ -87,6 +94,7 @@ impl IntoBuf for Vec<u8> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a Vec<u8> {
     type Buf = io::Cursor<&'a [u8]>;
 
@@ -97,6 +105,7 @@ impl<'a> IntoBuf for &'a Vec<u8> {
 
 // Kind of annoying... but this impl is required to allow passing `&'static
 // [u8]` where for<'a> &'a T: IntoBuf is required.
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a &'static [u8] {
     type Buf = io::Cursor<&'static [u8]>;
 
@@ -105,6 +114,7 @@ impl<'a> IntoBuf for &'a &'static [u8] {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a &'static str {
     type Buf = io::Cursor<&'static [u8]>;
 
@@ -113,6 +123,7 @@ impl<'a> IntoBuf for &'a &'static str {
     }
 }
 
+#[cfg(feature = "std")]
 impl IntoBuf for String {
     type Buf = io::Cursor<Vec<u8>>;
 
@@ -121,6 +132,7 @@ impl IntoBuf for String {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a String {
     type Buf = io::Cursor<&'a [u8]>;
 

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -24,6 +24,7 @@ mod into_buf;
 mod iter;
 mod reader;
 mod take;
+#[cfg(feature = "std")]
 mod vec_deque;
 mod writer;
 

--- a/src/buf/reader.rs
+++ b/src/buf/reader.rs
@@ -1,5 +1,6 @@
 use {Buf};
 
+#[cfg(feature = "std")]
 use std::{cmp, io};
 
 /// A `Buf` adapter which implements `io::Read` for the inner value.
@@ -78,6 +79,7 @@ impl<B: Buf> Reader<B> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<B: Buf + Sized> io::Read for Reader<B> {
     fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
         let len = cmp::min(self.buf.remaining(), dst.len());
@@ -87,6 +89,7 @@ impl<B: Buf + Sized> io::Read for Reader<B> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<B: Buf + Sized> io::BufRead for Reader<B> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         Ok(self.buf.bytes())

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -1,6 +1,6 @@
 use {Buf};
 
-use std::cmp;
+use core::cmp;
 
 /// A `Buf` adapter which limits the bytes read from an underlying buffer.
 ///

--- a/src/buf/vec_deque.rs
+++ b/src/buf/vec_deque.rs
@@ -24,6 +24,7 @@ impl Buf for VecDeque<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use prelude::*;
 
     #[test]
     fn hello_world() {

--- a/src/buf/writer.rs
+++ b/src/buf/writer.rs
@@ -1,5 +1,6 @@
 use BufMut;
 
+#[cfg(feature = "std")]
 use std::{cmp, io};
 
 /// A `BufMut` adapter which implements `io::Write` for the inner value.
@@ -74,6 +75,7 @@ impl<B: BufMut> Writer<B> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<B: BufMut + Sized> io::Write for Writer<B> {
     fn write(&mut self, src: &[u8]) -> io::Result<usize> {
         let n = cmp::min(self.buf.remaining_mut(), src.len());

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,6 +1,7 @@
 use {IntoBuf, Buf, BufMut};
 use buf::Iter;
 use debug;
+use prelude::*;
 
 use std::{cmp, fmt, mem, hash, ops, slice, ptr, usize};
 use std::borrow::{Borrow, BorrowMut};
@@ -1499,7 +1500,7 @@ impl BytesMut {
         }
 
         unsafe {
-            ptr = self.inner.ptr.offset(self.inner.len as isize); 
+            ptr = self.inner.ptr.offset(self.inner.len as isize);
         }
         if ptr == other.inner.ptr &&
            self.inner.kind() == KIND_ARC &&

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,13 @@
 
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/bytes/0.4.12")]
+#![no_std]
 
 extern crate byteorder;
+#[cfg(feature = "iovec")]
 extern crate iovec;
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod buf;
 pub use buf::{
@@ -88,9 +92,13 @@ pub use buf::{
     Take,
 };
 
+#[cfg(feature = "std")]
 mod bytes;
+#[cfg(feature = "std")]
 mod debug;
+#[cfg(feature = "std")]
 pub use bytes::{Bytes, BytesMut};
+mod prelude;
 
 #[deprecated]
 pub use byteorder::{ByteOrder, BigEndian, LittleEndian};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,5 @@
+//! Crate-local import prelude, primarily intended as a facade for accessing
+//! heap-allocated data structures.
+
+#[cfg(feature = "std")]
+pub use std::prelude::v1::*;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,8 +1,9 @@
 extern crate serde;
 
-use std::{cmp, fmt};
+use core::{cmp, fmt};
 use self::serde::{Serialize, Serializer, Deserialize, Deserializer, de};
 use super::{Bytes, BytesMut};
+use prelude::*;
 
 macro_rules! serde_impl {
     ($ty:ident, $visitor_ty:ident) => (


### PR DESCRIPTION
This PR revives #135 now that the [`alloc` crate is stable](https://github.com/rust-lang/rust/pull/59675), which unlocks using `bytes` in embedded RTOS environments or other embedded environments with enough RAM to warrant a heap (e.g. on SAMD51 uCs that have 192kB RAM).

Like the original #135 actual `alloc` support will be added in a subsequent PR, and this is a first pass to add initial `no_std` support and sanity check the approach.

In absence of upstream support for this, I've had to create [forks of bytes](https://github.com/microcrates/bytes) and [forks of downstream consumers of bytes](https://github.com/microcrates/prost), so it'd be really swell to get this all upstream rather than forking!