### PR TITLE
alloc support (for no_std environments)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ matrix:
     - env: EXTRA_ARGS="--no-default-features"
       script: cargo build $EXTRA_ARGS
 
+    # `alloc` crate-based implementation
+    - env: EXTRA_ARGS="--no-default-features --features=alloc --lib --tests"
+      rust: nightly # TODO: test 'alloc' on stable rust when it is fully stabilized
+
     # Serde implementation
     - env: EXTRA_ARGS="--features serde"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ matrix:
     - env: RUST_TEST_THREADS=1 TARGET=powerpc-unknown-linux-gnu
     - env: RUST_TEST_THREADS=1 TARGET=powerpc64-unknown-linux-gnu
 
+    # Ensure crate compiles without default features (i.e. for no_std)
+    - env: EXTRA_ARGS="--no-default-features"
+      script: cargo build $EXTRA_ARGS
+
     # Serde implementation
     - env: EXTRA_ARGS="--features serde"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,6 @@ serde_test = "1.0"
 
 [features]
 default = ["std"]
+alloc = []
 i128 = ["byteorder/i128"]
-std = ["iovec"]
+std = ["alloc", "iovec"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ exclude       = [
     "bench/**/*",
     "test/**/*"
 ]
-categories = ["network-programming", "data-structures"]
+categories = ["network-programming", "data-structures", "no-std"]
 
 [package.metadata.docs.rs]
 features = ["i128"]
 
 [dependencies]
 byteorder = "1.1.0"
-iovec = "0.1"
+iovec = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true }
 either = { version = "1.5", default-features = false, optional = true }
 
@@ -37,4 +37,6 @@ either = { version = "1.5", default-features = false, optional = true }
 serde_test = "1.0"
 
 [features]
+default = ["std"]
 i128 = ["byteorder/i128"]
+std = ["iovec"]

--- a/src/buf/buf.rs
+++ b/src/buf/buf.rs
@@ -2,7 +2,7 @@ use super::{IntoBuf, Take, Reader, Iter, FromBuf, Chain};
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
 #[cfg(feature = "iovec")]
 use iovec::IoVec;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use prelude::*;
 
 use core::{cmp, ptr};
@@ -1077,7 +1077,7 @@ impl<'a, T: Buf + ?Sized> Buf for &'a mut T {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<T: Buf + ?Sized> Buf for Box<T> {
     fn remaining(&self) -> usize {
         (**self).remaining()

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -2,7 +2,7 @@ use super::{IntoBuf, Writer};
 use byteorder::{LittleEndian, ByteOrder, BigEndian};
 #[cfg(feature = "iovec")]
 use iovec::IoVec;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use prelude::*;
 
 use core::{cmp, ptr, usize};
@@ -1088,7 +1088,7 @@ impl<'a, T: BufMut + ?Sized> BufMut for &'a mut T {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<T: BufMut + ?Sized> BufMut for Box<T> {
     fn remaining_mut(&self) -> usize {
         (**self).remaining_mut()
@@ -1098,6 +1098,7 @@ impl<T: BufMut + ?Sized> BufMut for Box<T> {
         (**self).bytes_mut()
     }
 
+    #[cfg(feature = "iovec")]
     unsafe fn bytes_vec_mut<'b>(&'b mut self, dst: &mut [&'b mut IoVec]) -> usize {
         (**self).bytes_vec_mut(dst)
     }
@@ -1136,7 +1137,7 @@ impl<T: AsMut<[u8]> + AsRef<[u8]>> BufMut for io::Cursor<T> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl BufMut for Vec<u8> {
     #[inline]
     fn remaining_mut(&self) -> usize {

--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -1,4 +1,5 @@
 use {Buf, BufMut};
+#[cfg(feature = "iovec")]
 use iovec::IoVec;
 
 /// A `Chain` sequences two buffers.
@@ -177,6 +178,7 @@ impl<T, U> Buf for Chain<T, U>
         self.b.advance(cnt);
     }
 
+    #[cfg(feature = "iovec")]
     fn bytes_vec<'a>(&'a self, dst: &mut [&'a IoVec]) -> usize {
         let mut n = self.a.bytes_vec(dst);
         n += self.b.bytes_vec(&mut dst[n..]);
@@ -218,6 +220,7 @@ impl<T, U> BufMut for Chain<T, U>
         self.b.advance_mut(cnt);
     }
 
+    #[cfg(feature = "iovec")]
     unsafe fn bytes_vec_mut<'a>(&'a mut self, dst: &mut [&'a mut IoVec]) -> usize {
         let mut n = self.a.bytes_vec_mut(dst);
         n += self.b.bytes_vec_mut(&mut dst[n..]);

--- a/src/buf/from_buf.rs
+++ b/src/buf/from_buf.rs
@@ -1,4 +1,8 @@
-use {Buf, BufMut, IntoBuf, Bytes, BytesMut};
+use {IntoBuf};
+#[cfg(feature = "std")]
+use prelude::*;
+#[cfg(feature = "std")]
+use {Buf, BufMut, Bytes, BytesMut};
 
 /// Conversion from a [`Buf`]
 ///
@@ -86,6 +90,7 @@ pub trait FromBuf {
     fn from_buf<T>(buf: T) -> Self where T: IntoBuf;
 }
 
+#[cfg(feature = "std")]
 impl FromBuf for Vec<u8> {
     fn from_buf<T>(buf: T) -> Self
         where T: IntoBuf
@@ -97,6 +102,7 @@ impl FromBuf for Vec<u8> {
     }
 }
 
+#[cfg(feature = "std")]
 impl FromBuf for Bytes {
     fn from_buf<T>(buf: T) -> Self
         where T: IntoBuf
@@ -105,6 +111,7 @@ impl FromBuf for Bytes {
     }
 }
 
+#[cfg(feature = "std")]
 impl FromBuf for BytesMut {
     fn from_buf<T>(buf: T) -> Self
         where T: IntoBuf

--- a/src/buf/from_buf.rs
+++ b/src/buf/from_buf.rs
@@ -1,7 +1,7 @@
 use {IntoBuf};
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use prelude::*;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use {Buf, BufMut, Bytes, BytesMut};
 
 /// Conversion from a [`Buf`]
@@ -90,7 +90,7 @@ pub trait FromBuf {
     fn from_buf<T>(buf: T) -> Self where T: IntoBuf;
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl FromBuf for Vec<u8> {
     fn from_buf<T>(buf: T) -> Self
         where T: IntoBuf
@@ -102,7 +102,7 @@ impl FromBuf for Vec<u8> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl FromBuf for Bytes {
     fn from_buf<T>(buf: T) -> Self
         where T: IntoBuf
@@ -111,7 +111,7 @@ impl FromBuf for Bytes {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl FromBuf for BytesMut {
     fn from_buf<T>(buf: T) -> Self
         where T: IntoBuf

--- a/src/buf/into_buf.rs
+++ b/src/buf/into_buf.rs
@@ -1,5 +1,8 @@
 use super::{Buf};
+#[cfg(feature = "std")]
+use prelude::*;
 
+#[cfg(feature = "std")]
 use std::io;
 
 /// Conversion into a `Buf`
@@ -55,6 +58,7 @@ impl<T: Buf> IntoBuf for T {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a [u8] {
     type Buf = io::Cursor<&'a [u8]>;
 
@@ -63,6 +67,7 @@ impl<'a> IntoBuf for &'a [u8] {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a mut [u8] {
     type Buf = io::Cursor<&'a mut [u8]>;
 
@@ -71,6 +76,7 @@ impl<'a> IntoBuf for &'a mut [u8] {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a str {
     type Buf = io::Cursor<&'a [u8]>;
 
@@ -79,6 +85,7 @@ impl<'a> IntoBuf for &'a str {
     }
 }
 
+#[cfg(feature = "std")]
 impl IntoBuf for Vec<u8> {
     type Buf = io::Cursor<Vec<u8>>;
 
@@ -87,6 +94,7 @@ impl IntoBuf for Vec<u8> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a Vec<u8> {
     type Buf = io::Cursor<&'a [u8]>;
 
@@ -97,6 +105,7 @@ impl<'a> IntoBuf for &'a Vec<u8> {
 
 // Kind of annoying... but this impl is required to allow passing `&'static
 // [u8]` where for<'a> &'a T: IntoBuf is required.
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a &'static [u8] {
     type Buf = io::Cursor<&'static [u8]>;
 
@@ -105,6 +114,7 @@ impl<'a> IntoBuf for &'a &'static [u8] {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a &'static str {
     type Buf = io::Cursor<&'static [u8]>;
 
@@ -113,6 +123,7 @@ impl<'a> IntoBuf for &'a &'static str {
     }
 }
 
+#[cfg(feature = "std")]
 impl IntoBuf for String {
     type Buf = io::Cursor<Vec<u8>>;
 
@@ -121,6 +132,7 @@ impl IntoBuf for String {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a String {
     type Buf = io::Cursor<&'a [u8]>;
 

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -24,6 +24,7 @@ mod into_buf;
 mod iter;
 mod reader;
 mod take;
+#[cfg(feature = "std")]
 mod vec_deque;
 mod writer;
 

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -24,7 +24,7 @@ mod into_buf;
 mod iter;
 mod reader;
 mod take;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod vec_deque;
 mod writer;
 

--- a/src/buf/reader.rs
+++ b/src/buf/reader.rs
@@ -1,5 +1,6 @@
 use {Buf};
 
+#[cfg(feature = "std")]
 use std::{cmp, io};
 
 /// A `Buf` adapter which implements `io::Read` for the inner value.
@@ -78,6 +79,7 @@ impl<B: Buf> Reader<B> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<B: Buf + Sized> io::Read for Reader<B> {
     fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
         let len = cmp::min(self.buf.remaining(), dst.len());
@@ -87,6 +89,7 @@ impl<B: Buf + Sized> io::Read for Reader<B> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<B: Buf + Sized> io::BufRead for Reader<B> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         Ok(self.buf.bytes())

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -1,6 +1,6 @@
 use {Buf};
 
-use std::cmp;
+use core::cmp;
 
 /// A `Buf` adapter which limits the bytes read from an underlying buffer.
 ///

--- a/src/buf/vec_deque.rs
+++ b/src/buf/vec_deque.rs
@@ -1,3 +1,6 @@
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::collections::vec_deque::VecDeque;
+#[cfg(feature = "std")]
 use std::collections::VecDeque;
 
 use super::Buf;

--- a/src/buf/vec_deque.rs
+++ b/src/buf/vec_deque.rs
@@ -24,6 +24,7 @@ impl Buf for VecDeque<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use prelude::*;
 
     #[test]
     fn hello_world() {

--- a/src/buf/writer.rs
+++ b/src/buf/writer.rs
@@ -1,5 +1,6 @@
 use BufMut;
 
+#[cfg(feature = "std")]
 use std::{cmp, io};
 
 /// A `BufMut` adapter which implements `io::Write` for the inner value.
@@ -74,6 +75,7 @@ impl<B: BufMut> Writer<B> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<B: BufMut + Sized> io::Write for Writer<B> {
     fn write(&mut self, src: &[u8]) -> io::Result<usize> {
         let n = cmp::min(self.buf.remaining_mut(), src.len());

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,14 +1,19 @@
-use {IntoBuf, Buf, BufMut};
+use {BufMut};
+#[cfg(feature = "std")]
+use {Buf, IntoBuf};
+#[cfg(feature = "std")]
 use buf::Iter;
 use debug;
 use prelude::*;
 
-use std::{cmp, fmt, mem, hash, ops, slice, ptr, usize};
-use std::borrow::{Borrow, BorrowMut};
+use core::{cmp, fmt, mem, hash, ops, slice, ptr, usize};
+use core::borrow::{Borrow, BorrowMut};
+use core::sync::atomic::{self, AtomicUsize, AtomicPtr};
+use core::sync::atomic::Ordering::{Relaxed, Acquire, Release, AcqRel};
+use core::iter::{FromIterator, Iterator};
+
+#[cfg(feature = "std")]
 use std::io::Cursor;
-use std::sync::atomic::{self, AtomicUsize, AtomicPtr};
-use std::sync::atomic::Ordering::{Relaxed, Acquire, Release, AcqRel};
-use std::iter::{FromIterator, Iterator};
 
 /// A reference counted contiguous slice of memory.
 ///
@@ -835,6 +840,7 @@ impl Bytes {
     }
 }
 
+#[cfg(feature = "std")]
 impl IntoBuf for Bytes {
     type Buf = Cursor<Self>;
 
@@ -843,6 +849,7 @@ impl IntoBuf for Bytes {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a Bytes {
     type Buf = Cursor<Self>;
 
@@ -986,6 +993,7 @@ impl Borrow<[u8]> for Bytes {
     }
 }
 
+#[cfg(feature = "std")]
 impl IntoIterator for Bytes {
     type Item = u8;
     type IntoIter = Iter<Cursor<Bytes>>;
@@ -995,6 +1003,7 @@ impl IntoIterator for Bytes {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoIterator for &'a Bytes {
     type Item = u8;
     type IntoIter = Iter<Cursor<&'a Bytes>>;
@@ -1563,6 +1572,7 @@ impl BufMut for BytesMut {
     }
 }
 
+#[cfg(feature = "std")]
 impl IntoBuf for BytesMut {
     type Buf = Cursor<Self>;
 
@@ -1571,6 +1581,7 @@ impl IntoBuf for BytesMut {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoBuf for &'a BytesMut {
     type Buf = Cursor<&'a BytesMut>;
 
@@ -1736,6 +1747,7 @@ impl Clone for BytesMut {
     }
 }
 
+#[cfg(feature = "std")]
 impl IntoIterator for BytesMut {
     type Item = u8;
     type IntoIter = Iter<Cursor<BytesMut>>;
@@ -1745,6 +1757,7 @@ impl IntoIterator for BytesMut {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoIterator for &'a BytesMut {
     type Item = u8;
     type IntoIter = Iter<Cursor<&'a BytesMut>>;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,6 +1,7 @@
 use {IntoBuf, Buf, BufMut};
 use buf::Iter;
 use debug;
+use prelude::*;
 
 use std::{cmp, fmt, mem, hash, ops, slice, ptr, usize};
 use std::borrow::{Borrow, BorrowMut};
@@ -1499,7 +1500,7 @@ impl BytesMut {
         }
 
         unsafe {
-            ptr = self.inner.ptr.offset(self.inner.len as isize); 
+            ptr = self.inner.ptr.offset(self.inner.len as isize);
         }
         if ptr == other.inner.ptr &&
            self.inner.kind() == KIND_ARC &&

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 /// Alternative implementation of `fmt::Debug` for byte slice.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,13 @@
 
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/bytes/0.4.12")]
+#![no_std]
 
 extern crate byteorder;
+#[cfg(feature = "iovec")]
 extern crate iovec;
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod buf;
 pub use buf::{
@@ -88,9 +92,13 @@ pub use buf::{
     Take,
 };
 
+#[cfg(feature = "std")]
 mod bytes;
+#[cfg(feature = "std")]
 mod debug;
+#[cfg(feature = "std")]
 pub use bytes::{Bytes, BytesMut};
+mod prelude;
 
 #[deprecated]
 pub use byteorder::{ByteOrder, BigEndian, LittleEndian};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@
 #![doc(html_root_url = "https://docs.rs/bytes/0.4.12")]
 #![no_std]
 
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+extern crate alloc;
 extern crate byteorder;
 #[cfg(feature = "iovec")]
 extern crate iovec;
@@ -92,13 +94,13 @@ pub use buf::{
     Take,
 };
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod bytes;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod debug;
-#[cfg(feature = "std")]
-pub use bytes::{Bytes, BytesMut};
 mod prelude;
+#[cfg(feature = "alloc")]
+pub use bytes::{Bytes, BytesMut};
 
 #[deprecated]
 pub use byteorder::{ByteOrder, BigEndian, LittleEndian};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,12 @@
 //! Crate-local import prelude, primarily intended as a facade for accessing
 //! heap-allocated data structures.
 
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+pub use alloc::boxed::Box;
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+pub use alloc::string::String;
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+pub use alloc::vec::Vec;
+
 #[cfg(feature = "std")]
 pub use std::prelude::v1::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,5 @@
+//! Crate-local import prelude, primarily intended as a facade for accessing
+//! heap-allocated data structures.
+
+#[cfg(feature = "std")]
+pub use std::prelude::v1::*;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,8 +1,9 @@
 extern crate serde;
 
-use std::{cmp, fmt};
+use core::{cmp, fmt};
 use self::serde::{Serialize, Serializer, Deserialize, Deserializer, de};
 use super::{Bytes, BytesMut};
+use prelude::*;
 
 macro_rules! serde_impl {
     ($ty:ident, $visitor_ty:ident) => (

--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -1,12 +1,17 @@
 extern crate bytes;
 extern crate byteorder;
+#[cfg(feature = "iovec")]
 extern crate iovec;
 
+#[cfg(feature = "std")]
 use bytes::Buf;
+#[cfg(feature = "iovec")]
 use iovec::IoVec;
+#[cfg(feature = "std")]
 use std::io::Cursor;
 
 #[test]
+#[cfg(feature = "std")]
 fn test_fresh_cursor_vec() {
     let mut buf = Cursor::new(b"hello".to_vec());
 
@@ -25,12 +30,14 @@ fn test_fresh_cursor_vec() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_get_u8() {
     let mut buf = Cursor::new(b"\x21zomg");
     assert_eq!(0x21, buf.get_u8());
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_get_u16() {
     let buf = b"\x21\x54zomg";
     assert_eq!(0x2154, Cursor::new(buf).get_u16_be());
@@ -39,12 +46,14 @@ fn test_get_u16() {
 
 #[test]
 #[should_panic]
+#[cfg(feature = "std")]
 fn test_get_u16_buffer_underflow() {
     let mut buf = Cursor::new(b"\x21");
     buf.get_u16_be();
 }
 
 #[test]
+#[cfg(all(feature = "iovec", feature = "std"))]
 fn test_bufs_vec() {
     let buf = Cursor::new(b"hello world");
 

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -1,13 +1,20 @@
 extern crate bytes;
 extern crate byteorder;
+#[cfg(feature = "iovec")]
 extern crate iovec;
 
-use bytes::{BufMut, BytesMut};
+use bytes::BufMut;
+#[cfg(feature = "std")]
+use bytes::BytesMut;
+#[cfg(feature = "iovec")]
 use iovec::IoVec;
+#[cfg(feature = "std")]
 use std::usize;
+#[cfg(feature = "std")]
 use std::fmt::Write;
 
 #[test]
+#[cfg(feature = "std")]
 fn test_vec_as_mut_buf() {
     let mut buf = Vec::with_capacity(64);
 
@@ -61,6 +68,7 @@ fn test_vec_advance_mut() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_clone() {
     let mut buf = BytesMut::with_capacity(100);
     buf.write_str("this is a test").unwrap();
@@ -71,6 +79,7 @@ fn test_clone() {
 }
 
 #[test]
+#[cfg(feature = "iovec")]
 fn test_bufs_vec_mut() {
     use std::mem;
 

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1,6 +1,8 @@
 extern crate bytes;
 
-use bytes::{Bytes, BytesMut, BufMut, IntoBuf};
+use bytes::{Bytes, BytesMut, BufMut};
+#[cfg(feature = "std")]
+use bytes::IntoBuf;
 
 const LONG: &'static [u8] = b"mary had a little lamb, little lamb, little lamb";
 const SHORT: &'static [u8] = b"hello world";
@@ -166,6 +168,7 @@ fn split_off_uninitialized() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn split_off_to_loop() {
     let s = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -299,6 +302,7 @@ fn fns_defined_for_bytes_mut() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn mut_into_buf() {
     let mut v = vec![0, 0, 0, 0];
     let s = &mut v[..];
@@ -306,6 +310,7 @@ fn mut_into_buf() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn reserve_convert() {
     // Inline -> Vec
     let mut bytes = BytesMut::with_capacity(8);
@@ -341,6 +346,7 @@ fn reserve_convert() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn reserve_growth() {
     let mut bytes = BytesMut::with_capacity(64);
     bytes.put("hello world");
@@ -385,6 +391,7 @@ fn reserve_max_original_capacity_value() {
 // within the program that this actually recycles memory. Instead, just exercise
 // the code path to ensure that the results are correct.
 #[test]
+#[cfg(feature = "std")]
 fn reserve_vec_recycling() {
     let mut bytes = BytesMut::from(Vec::with_capacity(16));
     assert_eq!(bytes.capacity(), 16);
@@ -432,6 +439,7 @@ fn reserve_in_arc_nonunique_does_not_overallocate() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn inline_storage() {
     let mut bytes = BytesMut::with_capacity(inline_cap());
     let zero = [0u8; 64];
@@ -524,7 +532,7 @@ fn advance_past_len() {
 #[test]
 // Only run these tests on little endian systems. CI uses qemu for testing
 // little endian... and qemu doesn't really support threading all that well.
-#[cfg(target_endian = "little")]
+#[cfg(all(target_endian = "little", feature = "std"))]
 fn stress() {
     // Tests promoting a buffer from a vec -> shared in a concurrent situation
     use std::sync::{Arc, Barrier};

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -1,12 +1,18 @@
 extern crate bytes;
+#[cfg(feature = "iovec")]
 extern crate iovec;
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{BufMut, BytesMut};
+#[cfg(feature = "std")]
+use bytes::{Buf, Bytes};
 use bytes::buf::Chain;
+#[cfg(feature = "iovec")]
 use iovec::IoVec;
+#[cfg(feature = "std")]
 use std::io::Cursor;
 
 #[test]
+#[cfg(feature = "std")]
 fn collect_two_bufs() {
     let a = Cursor::new(Bytes::from(&b"hello"[..]));
     let b = Cursor::new(Bytes::from(&b"world"[..]));
@@ -39,6 +45,7 @@ fn writing_chained() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn iterating_two_bufs() {
     let a = Cursor::new(Bytes::from(&b"hello"[..]));
     let b = Cursor::new(Bytes::from(&b"world"[..]));
@@ -48,6 +55,7 @@ fn iterating_two_bufs() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn vectored_read() {
     let a = Cursor::new(Bytes::from(&b"hello"[..]));
     let b = Cursor::new(Bytes::from(&b"world"[..]));

--- a/tests/test_from_buf.rs
+++ b/tests/test_from_buf.rs
@@ -1,12 +1,17 @@
 extern crate bytes;
 
+#[cfg(feature = "std")]
 use bytes::{Buf, Bytes, BytesMut};
+#[cfg(feature = "std")]
 use std::io::Cursor;
 
+#[cfg(feature = "std")]
 const LONG: &'static [u8] = b"mary had a little lamb, little lamb, little lamb";
+#[cfg(feature = "std")]
 const SHORT: &'static [u8] = b"hello world";
 
 #[test]
+#[cfg(feature = "std")]
 fn collect_to_vec() {
     let buf: Vec<u8> = Cursor::new(SHORT).collect();
     assert_eq!(buf, SHORT);
@@ -16,6 +21,7 @@ fn collect_to_vec() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn collect_to_bytes() {
     let buf: Bytes = Cursor::new(SHORT).collect();
     assert_eq!(buf, SHORT);
@@ -25,6 +31,7 @@ fn collect_to_bytes() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn collect_to_bytes_mut() {
     let buf: BytesMut = Cursor::new(SHORT).collect();
     assert_eq!(buf, SHORT);

--- a/tests/test_iter.rs
+++ b/tests/test_iter.rs
@@ -1,8 +1,10 @@
 extern crate bytes;
 
+#[cfg(feature = "std")]
 use bytes::{Buf, IntoBuf, Bytes};
 
 #[test]
+#[cfg(feature = "std")]
 fn iter_len() {
     let buf = Bytes::from(&b"hello world"[..]).into_buf();
     let iter = buf.iter();
@@ -13,6 +15,7 @@ fn iter_len() {
 
 
 #[test]
+#[cfg(feature = "std")]
 fn empty_iter_len() {
     let buf = Bytes::from(&b""[..]).into_buf();
     let iter = buf.iter();

--- a/tests/test_reader.rs
+++ b/tests/test_reader.rs
@@ -1,10 +1,12 @@
 extern crate bytes;
 
+#[cfg(feature = "std")]
 use std::io::{BufRead, Cursor, Read};
-
+#[cfg(feature = "std")]
 use bytes::Buf;
 
 #[test]
+#[cfg(feature = "std")]
 fn read() {
     let buf1 = Cursor::new(b"hello ");
     let buf2 = Cursor::new(b"world");
@@ -15,6 +17,7 @@ fn read() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn buf_read() {
     let buf1 = Cursor::new(b"hell");
     let buf2 = Cursor::new(b"o\nworld");

--- a/tests/test_take.rs
+++ b/tests/test_take.rs
@@ -1,9 +1,12 @@
 extern crate bytes;
 
+#[cfg(feature = "std")]
 use bytes::Buf;
+#[cfg(feature = "std")]
 use std::io::Cursor;
 
 #[test]
+#[cfg(feature = "std")]
 fn long_take() {
     // Tests that take with a size greater than the buffer length will not
     // overrun the buffer. Regression test for #138.


### PR DESCRIPTION
This PR revives #153 and includes #255. I'm reopening it because the [`alloc` crate is now stable](https://github.com/rust-lang/rust/pull/59675), which should hopefully address the previous concerns about #153 being `nightly`-dependent.

It gates all allocator-dependent features on the `alloc` cargo feature, enabling use of much of the functionality in `no_std` environments which have a heap and defined allocator, but not full support for 'std'.

Unlike previous attempts, this PR runs the parts of the test suite which do not require `std` as part of CI, ensuring that `alloc` support is properly tested. For now this requires `nightly`, but when `alloc` stabilization lands in the `stable` channel, it should be possible to always test `alloc` support in all environments.