### PR TITLE
Deprecate BytesMut::take(), renamed to split()

### DIFF
--- a/src/buf/buf.rs
+++ b/src/buf/buf.rs
@@ -1151,4 +1151,7 @@ impl Buf for Option<[u8; 1]> {
 
 // The existance of this function makes the compiler catch if the Buf
 // trait is "object-safe" or not.
+//
+// XXX: The allow() is required while our minimum Rust version is less than 1.26.
+#[allow(warnings)]
 fn _assert_trait_object(_b: &Buf) {}

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -1164,4 +1164,7 @@ impl BufMut for Vec<u8> {
 
 // The existance of this function makes the compiler catch if the BufMut
 // trait is "object-safe" or not.
+//
+// XXX: The allow() is required while our minimum Rust version is less than 1.26.
+#[allow(warnings)]
 fn _assert_trait_object(_b: &BufMut) {}

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1220,22 +1220,29 @@ impl BytesMut {
     /// let mut buf = BytesMut::with_capacity(1024);
     /// buf.put(&b"hello world"[..]);
     ///
-    /// let other = buf.take();
+    /// let other = buf.split();
     ///
     /// assert!(buf.is_empty());
     /// assert_eq!(1013, buf.capacity());
     ///
     /// assert_eq!(other, b"hello world"[..]);
     /// ```
-    pub fn take(&mut self) -> BytesMut {
+    pub fn split(&mut self) -> BytesMut {
         let len = self.len();
         self.split_to(len)
     }
 
-    #[deprecated(since = "0.4.1", note = "use take instead")]
+    #[deprecated(since = "0.4.13", note = "use split instead")]
+    #[doc(hidden)]
+    // Name conflict with `Buf::take()`
+    pub fn take(&mut self) -> BytesMut {
+        self.split()
+    }
+
+    #[deprecated(since = "0.4.1", note = "use split instead")]
     #[doc(hidden)]
     pub fn drain(&mut self) -> BytesMut {
-        self.take()
+        self.split()
     }
 
     /// Splits the buffer into two at the given index.

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -344,7 +344,7 @@ fn reserve_convert() {
 fn reserve_growth() {
     let mut bytes = BytesMut::with_capacity(64);
     bytes.put("hello world");
-    let _ = bytes.take();
+    let _ = bytes.split();
 
     bytes.reserve(65);
     assert_eq!(bytes.capacity(), 128);
@@ -358,7 +358,7 @@ fn reserve_allocates_at_least_original_capacity() {
         bytes.put(i as u8);
     }
 
-    let _other = bytes.take();
+    let _other = bytes.split();
 
     bytes.reserve(16);
     assert_eq!(bytes.capacity(), 1024);
@@ -374,7 +374,7 @@ fn reserve_max_original_capacity_value() {
         bytes.put(0u8);
     }
 
-    let _other = bytes.take();
+    let _other = bytes.split();
 
     bytes.reserve(16);
     assert_eq!(bytes.capacity(), 64 * 1024);
@@ -398,7 +398,7 @@ fn reserve_vec_recycling() {
 #[test]
 fn reserve_in_arc_unique_does_not_overallocate() {
     let mut bytes = BytesMut::with_capacity(1000);
-    bytes.take();
+    bytes.split();
 
     // now bytes is Arc and refcount == 1
 
@@ -410,7 +410,7 @@ fn reserve_in_arc_unique_does_not_overallocate() {
 #[test]
 fn reserve_in_arc_unique_doubles() {
     let mut bytes = BytesMut::with_capacity(1000);
-    bytes.take();
+    bytes.split();
 
     // now bytes is Arc and refcount == 1
 
@@ -422,7 +422,7 @@ fn reserve_in_arc_unique_doubles() {
 #[test]
 fn reserve_in_arc_nonunique_does_not_overallocate() {
     let mut bytes = BytesMut::with_capacity(1000);
-    let _copy = bytes.take();
+    let _copy = bytes.split();
 
     // now bytes is Arc and refcount == 2
 


### PR DESCRIPTION
In 0.5, we wish to implement `Buf` for `BytesMut`, and there is a name conflict with `Buf::take()`. To prepare for it now, rename the current `BytesMut::take()` to `BytesMut::split()`. The docs help with the name choice: it's the same as `bytes.split_to(bytes.len())`.