### PR TITLE
impl Buf for Bytes and BytesMut

### DIFF
--- a/src/buf/buf.rs
+++ b/src/buf/buf.rs
@@ -1,4 +1,4 @@
-use super::{IntoBuf, Take, Reader, Iter, FromBuf, Chain};
+use super::{IntoBuf, Take, Reader, FromBuf, Chain};
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use iovec::IoVec;
 
@@ -47,10 +47,10 @@ macro_rules! buf_get_impl {
 /// The simplest `Buf` is a `Cursor` wrapping a `[u8]`.
 ///
 /// ```
-/// use bytes::Buf;
+/// use bytes::{Buf, Bytes};
 /// use std::io::Cursor;
 ///
-/// let mut buf = Cursor::new(b"hello world");
+/// let mut buf = Bytes::from_static(b"hello world");
 ///
 /// assert_eq!(b'h', buf.get_u8());
 /// assert_eq!(b'e', buf.get_u8());
@@ -71,10 +71,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"hello world");
+    /// let mut buf = Bytes::from_static(b"hello world");
     ///
     /// assert_eq!(buf.remaining(), 11);
     ///
@@ -100,10 +99,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"hello world");
+    /// let mut buf = Bytes::from_static(b"hello world");
     ///
     /// assert_eq!(buf.bytes(), b"hello world");
     ///
@@ -167,10 +165,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"hello world");
+    /// let mut buf = Bytes::from_static(b"hello world");
     ///
     /// assert_eq!(buf.bytes(), b"hello world");
     ///
@@ -199,10 +196,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"a");
+    /// let mut buf = Bytes::from_static(b"a");
     ///
     /// assert!(buf.has_remaining());
     ///
@@ -222,10 +218,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"hello world");
+    /// let mut buf = Bytes::from_static(b"hello world");
     /// let mut dst = [0; 5];
     ///
     /// buf.copy_to_slice(&mut dst);
@@ -265,10 +260,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x08 hello");
+    /// let mut buf = Bytes::from_static(b"\x08 hello");
     /// assert_eq!(8, buf.get_u8());
     /// ```
     ///
@@ -289,10 +283,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x08 hello");
+    /// let mut buf = Bytes::from_static(b"\x08 hello");
     /// assert_eq!(8, buf.get_i8());
     /// ```
     ///
@@ -313,10 +306,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x08\x09 hello");
+    /// let mut buf = Bytes::from_static(b"\x08\x09 hello");
     /// assert_eq!(0x0809, buf.get_u16());
     /// ```
     ///
@@ -334,10 +326,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x09\x08 hello");
+    /// let mut buf = Bytes::from_static(b"\x09\x08 hello");
     /// assert_eq!(0x0809, buf.get_u16_le());
     /// ```
     ///
@@ -355,10 +346,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x08\x09 hello");
+    /// let mut buf = Bytes::from_static(b"\x08\x09 hello");
     /// assert_eq!(0x0809, buf.get_i16());
     /// ```
     ///
@@ -376,10 +366,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x09\x08 hello");
+    /// let mut buf = Bytes::from_static(b"\x09\x08 hello");
     /// assert_eq!(0x0809, buf.get_i16_le());
     /// ```
     ///
@@ -397,10 +386,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x08\x09\xA0\xA1 hello");
+    /// let mut buf = Bytes::from_static(b"\x08\x09\xA0\xA1 hello");
     /// assert_eq!(0x0809A0A1, buf.get_u32());
     /// ```
     ///
@@ -418,10 +406,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\xA1\xA0\x09\x08 hello");
+    /// let mut buf = Bytes::from_static(b"\xA1\xA0\x09\x08 hello");
     /// assert_eq!(0x0809A0A1, buf.get_u32_le());
     /// ```
     ///
@@ -439,10 +426,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x08\x09\xA0\xA1 hello");
+    /// let mut buf = Bytes::from_static(b"\x08\x09\xA0\xA1 hello");
     /// assert_eq!(0x0809A0A1, buf.get_i32());
     /// ```
     ///
@@ -460,10 +446,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\xA1\xA0\x09\x08 hello");
+    /// let mut buf = Bytes::from_static(b"\xA1\xA0\x09\x08 hello");
     /// assert_eq!(0x0809A0A1, buf.get_i32_le());
     /// ```
     ///
@@ -481,10 +466,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x01\x02\x03\x04\x05\x06\x07\x08 hello");
+    /// let mut buf = Bytes::from_static(b"\x01\x02\x03\x04\x05\x06\x07\x08 hello");
     /// assert_eq!(0x0102030405060708, buf.get_u64());
     /// ```
     ///
@@ -502,10 +486,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x08\x07\x06\x05\x04\x03\x02\x01 hello");
+    /// let mut buf = Bytes::from_static(b"\x08\x07\x06\x05\x04\x03\x02\x01 hello");
     /// assert_eq!(0x0102030405060708, buf.get_u64_le());
     /// ```
     ///
@@ -523,10 +506,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x01\x02\x03\x04\x05\x06\x07\x08 hello");
+    /// let mut buf = Bytes::from_static(b"\x01\x02\x03\x04\x05\x06\x07\x08 hello");
     /// assert_eq!(0x0102030405060708, buf.get_i64());
     /// ```
     ///
@@ -544,10 +526,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x08\x07\x06\x05\x04\x03\x02\x01 hello");
+    /// let mut buf = Bytes::from_static(b"\x08\x07\x06\x05\x04\x03\x02\x01 hello");
     /// assert_eq!(0x0102030405060708, buf.get_i64_le());
     /// ```
     ///
@@ -657,10 +638,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x01\x02\x03 hello");
+    /// let mut buf = Bytes::from_static(b"\x01\x02\x03 hello");
     /// assert_eq!(0x010203, buf.get_uint(3));
     /// ```
     ///
@@ -678,10 +658,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x03\x02\x01 hello");
+    /// let mut buf = Bytes::from_static(b"\x03\x02\x01 hello");
     /// assert_eq!(0x010203, buf.get_uint_le(3));
     /// ```
     ///
@@ -699,10 +678,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x01\x02\x03 hello");
+    /// let mut buf = Bytes::from_static(b"\x01\x02\x03 hello");
     /// assert_eq!(0x010203, buf.get_int(3));
     /// ```
     ///
@@ -720,10 +698,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x03\x02\x01 hello");
+    /// let mut buf = Bytes::from_static(b"\x03\x02\x01 hello");
     /// assert_eq!(0x010203, buf.get_int_le(3));
     /// ```
     ///
@@ -742,10 +719,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x3F\x99\x99\x9A hello");
+    /// let mut buf = Bytes::from_static(b"\x3F\x99\x99\x9A hello");
     /// assert_eq!(1.2f32, buf.get_f32());
     /// ```
     ///
@@ -764,10 +740,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x9A\x99\x99\x3F hello");
+    /// let mut buf = Bytes::from_static(b"\x9A\x99\x99\x3F hello");
     /// assert_eq!(1.2f32, buf.get_f32_le());
     /// ```
     ///
@@ -786,10 +761,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x3F\xF3\x33\x33\x33\x33\x33\x33 hello");
+    /// let mut buf = Bytes::from_static(b"\x3F\xF3\x33\x33\x33\x33\x33\x33 hello");
     /// assert_eq!(1.2f64, buf.get_f64());
     /// ```
     ///
@@ -808,10 +782,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"\x33\x33\x33\x33\x33\x33\xF3\x3F hello");
+    /// let mut buf = Bytes::from_static(b"\x33\x33\x33\x33\x33\x33\xF3\x3F hello");
     /// assert_eq!(1.2f64, buf.get_f64_le());
     /// ```
     ///
@@ -854,10 +827,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Buf, BufMut};
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, BufMut, Bytes};
     ///
-    /// let mut buf = Cursor::new("hello world").take(5);
+    /// let mut buf = Bytes::from_static(b"hello world").take(5);
     /// let mut dst = vec![];
     ///
     /// dst.put(&mut buf);
@@ -882,13 +854,13 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Bytes, Buf, IntoBuf};
+    /// use bytes::{Bytes, Buf};
     /// use bytes::buf::Chain;
     ///
-    /// let buf = Bytes::from(&b"hello "[..]).into_buf()
+    /// let chain = Bytes::from_static(b"hello ")
     ///             .chain(Bytes::from(&b"world"[..]));
     ///
-    /// let full: Bytes = buf.collect();
+    /// let full: Bytes = chain.collect();
     /// assert_eq!(full[..], b"hello world"[..]);
     /// ```
     fn chain<U>(self, next: U) -> Chain<Self, U::Buf>
@@ -905,10 +877,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Buf, BufMut};
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, BufMut, Bytes};
     ///
-    /// let mut buf = Cursor::new("hello world");
+    /// let mut buf = Bytes::from_static(b"hello world");
     /// let mut dst = vec![];
     ///
     /// {
@@ -950,25 +921,6 @@ pub trait Buf {
     /// ```
     fn reader(self) -> Reader<Self> where Self: Sized {
         super::reader::new(self)
-    }
-
-    /// Returns an iterator over the bytes contained by the buffer.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bytes::{Buf, IntoBuf, Bytes};
-    ///
-    /// let buf = Bytes::from(&b"abc"[..]).into_buf();
-    /// let mut iter = buf.iter();
-    ///
-    /// assert_eq!(iter.next(), Some(b'a'));
-    /// assert_eq!(iter.next(), Some(b'b'));
-    /// assert_eq!(iter.next(), Some(b'c'));
-    /// assert_eq!(iter.next(), None);
-    /// ```
-    fn iter(self) -> Iter<Self> where Self: Sized {
-        super::iter::new(self)
     }
 }
 

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -34,16 +34,15 @@ pub trait BufMut {
     /// # Examples
     ///
     /// ```
-    /// use bytes::BufMut;
-    /// use std::io::Cursor;
+    /// use bytes::{BufMut, BytesMut};
     ///
-    /// let mut dst = [0; 10];
-    /// let mut buf = Cursor::new(&mut dst[..]);
+    /// let mut src = [0u8; 10];
+    /// let mut buf = BytesMut::from(&src[..]);
     ///
-    /// assert_eq!(10, buf.remaining_mut());
+    /// let original_remaining = buf.remaining_mut();
     /// buf.put("hello");
     ///
-    /// assert_eq!(5, buf.remaining_mut());
+    /// assert_eq!(original_remaining - 5, buf.remaining_mut());
     /// ```
     ///
     /// # Implementer notes

--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -1,4 +1,5 @@
 use {Buf, BufMut};
+use buf::IntoIter;
 use iovec::{IoVec, IoVecMut};
 
 /// A `Chain` sequences two buffers.
@@ -64,7 +65,7 @@ impl<T, U> Chain<T, U> {
     /// let buf = Bytes::from(&b"hello"[..]).into_buf()
     ///             .chain(Bytes::from(&b"world"[..]));
     ///
-    /// assert_eq!(buf.first_ref().get_ref()[..], b"hello"[..]);
+    /// assert_eq!(buf.first_ref()[..], b"hello"[..]);
     /// ```
     pub fn first_ref(&self) -> &T {
         &self.a
@@ -80,7 +81,7 @@ impl<T, U> Chain<T, U> {
     /// let mut buf = Bytes::from(&b"hello "[..]).into_buf()
     ///                 .chain(Bytes::from(&b"world"[..]));
     ///
-    /// buf.first_mut().set_position(1);
+    /// buf.first_mut().advance(1);
     ///
     /// let full: Bytes = buf.collect();
     /// assert_eq!(full[..], b"ello world"[..]);
@@ -99,7 +100,7 @@ impl<T, U> Chain<T, U> {
     /// let buf = Bytes::from(&b"hello"[..]).into_buf()
     ///             .chain(Bytes::from(&b"world"[..]));
     ///
-    /// assert_eq!(buf.last_ref().get_ref()[..], b"world"[..]);
+    /// assert_eq!(buf.last_ref()[..], b"world"[..]);
     /// ```
     pub fn last_ref(&self) -> &U {
         &self.b
@@ -115,7 +116,7 @@ impl<T, U> Chain<T, U> {
     /// let mut buf = Bytes::from(&b"hello "[..]).into_buf()
     ///                 .chain(Bytes::from(&b"world"[..]));
     ///
-    /// buf.last_mut().set_position(1);
+    /// buf.last_mut().advance(1);
     ///
     /// let full: Bytes = buf.collect();
     /// assert_eq!(full[..], b"hello orld"[..]);
@@ -129,14 +130,14 @@ impl<T, U> Chain<T, U> {
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Bytes, Buf, IntoBuf};
+    /// use bytes::{Bytes, Buf};
     ///
-    /// let buf = Bytes::from(&b"hello"[..]).into_buf()
+    /// let chain = Bytes::from(&b"hello"[..])
     ///             .chain(Bytes::from(&b"world"[..]));
     ///
-    /// let (first, last) = buf.into_inner();
-    /// assert_eq!(first.get_ref()[..], b"hello"[..]);
-    /// assert_eq!(last.get_ref()[..], b"world"[..]);
+    /// let (first, last) = chain.into_inner();
+    /// assert_eq!(first[..], b"hello"[..]);
+    /// assert_eq!(last[..], b"world"[..]);
     /// ```
     pub fn into_inner(self) -> (T, U) {
         (self.a, self.b)
@@ -222,5 +223,18 @@ impl<T, U> BufMut for Chain<T, U>
         let mut n = self.a.bytes_vec_mut(dst);
         n += self.b.bytes_vec_mut(&mut dst[n..]);
         n
+    }
+}
+
+impl<T, U> IntoIterator for Chain<T, U>
+where
+    T: Buf,
+    U: Buf,
+{
+    type Item = u8;
+    type IntoIter = IntoIter<Chain<T, U>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter::new(self)
     }
 }

--- a/src/buf/iter.rs
+++ b/src/buf/iter.rs
@@ -12,7 +12,7 @@ use Buf;
 /// use bytes::{Buf, IntoBuf, Bytes};
 ///
 /// let buf = Bytes::from(&b"abc"[..]).into_buf();
-/// let mut iter = buf.iter();
+/// let mut iter = buf.into_iter();
 ///
 /// assert_eq!(iter.next(), Some(b'a'));
 /// assert_eq!(iter.next(), Some(b'b'));
@@ -23,12 +23,31 @@ use Buf;
 /// [`iter`]: trait.Buf.html#method.iter
 /// [`Buf`]: trait.Buf.html
 #[derive(Debug)]
-pub struct Iter<T> {
+pub struct IntoIter<T> {
     inner: T,
 }
 
-impl<T> Iter<T> {
-    /// Consumes this `Iter`, returning the underlying value.
+impl<T> IntoIter<T> {
+    /// Creates an iterator over the bytes contained by the buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::{Buf, Bytes};
+    /// use bytes::buf::IntoIter;
+    ///
+    /// let buf = Bytes::from_static(b"abc");
+    /// let mut iter = IntoIter::new(buf);
+    ///
+    /// assert_eq!(iter.next(), Some(b'a'));
+    /// assert_eq!(iter.next(), Some(b'b'));
+    /// assert_eq!(iter.next(), Some(b'c'));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn new(inner: T) -> IntoIter<T> {
+        IntoIter { inner: inner }
+    }
+    /// Consumes this `IntoIter`, returning the underlying value.
     ///
     /// # Examples
     ///
@@ -36,7 +55,7 @@ impl<T> Iter<T> {
     /// use bytes::{Buf, IntoBuf, Bytes};
     ///
     /// let buf = Bytes::from(&b"abc"[..]).into_buf();
-    /// let mut iter = buf.iter();
+    /// let mut iter = buf.into_iter();
     ///
     /// assert_eq!(iter.next(), Some(b'a'));
     ///
@@ -57,7 +76,7 @@ impl<T> Iter<T> {
     /// use bytes::{Buf, IntoBuf, Bytes};
     ///
     /// let buf = Bytes::from(&b"abc"[..]).into_buf();
-    /// let mut iter = buf.iter();
+    /// let mut iter = buf.into_iter();
     ///
     /// assert_eq!(iter.next(), Some(b'a'));
     ///
@@ -76,25 +95,22 @@ impl<T> Iter<T> {
     /// ```rust
     /// use bytes::{Buf, IntoBuf, BytesMut};
     ///
-    /// let buf = BytesMut::from(&b"abc"[..]).into_buf();
-    /// let mut iter = buf.iter();
+    /// let buf = BytesMut::from(&b"abc"[..]);
+    /// let mut iter = buf.into_iter();
     ///
     /// assert_eq!(iter.next(), Some(b'a'));
     ///
-    /// iter.get_mut().set_position(0);
+    /// iter.get_mut().advance(1);
     ///
-    /// assert_eq!(iter.next(), Some(b'a'));
+    /// assert_eq!(iter.next(), Some(b'c'));
     /// ```
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.inner
     }
 }
 
-pub fn new<T>(inner: T) -> Iter<T> {
-    Iter { inner: inner }
-}
 
-impl<T: Buf> Iterator for Iter<T> {
+impl<T: Buf> Iterator for IntoIter<T> {
     type Item = u8;
 
     fn next(&mut self) -> Option<u8> {
@@ -104,6 +120,7 @@ impl<T: Buf> Iterator for Iter<T> {
 
         let b = self.inner.bytes()[0];
         self.inner.advance(1);
+
         Some(b)
     }
 
@@ -113,4 +130,4 @@ impl<T: Buf> Iterator for Iter<T> {
     }
 }
 
-impl<T: Buf> ExactSizeIterator for Iter<T> { }
+impl<T: Buf> ExactSizeIterator for IntoIter<T> { }

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -32,7 +32,7 @@ pub use self::buf_mut::BufMut;
 pub use self::from_buf::FromBuf;
 pub use self::chain::Chain;
 pub use self::into_buf::IntoBuf;
-pub use self::iter::Iter;
+pub use self::iter::IntoIter;
 pub use self::reader::Reader;
 pub use self::take::Take;
 pub use self::writer::Writer;

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -25,10 +25,9 @@ impl<T> Take<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use bytes::{Buf, BufMut};
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, BufMut, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"hello world").take(2);
+    /// let mut buf = Bytes::from_static(b"hello world").take(2);
     /// let mut dst = vec![];
     ///
     /// dst.put(&mut buf);
@@ -51,12 +50,11 @@ impl<T> Take<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use bytes::{Buf, BufMut};
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, BufMut, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"hello world").take(2);
+    /// let mut buf = Bytes::from_static(b"hello world").take(2);
     ///
-    /// assert_eq!(0, buf.get_ref().position());
+    /// assert_eq!(11, buf.get_ref().remaining());
     /// ```
     pub fn get_ref(&self) -> &T {
         &self.inner
@@ -69,13 +67,12 @@ impl<T> Take<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use bytes::{Buf, BufMut};
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, BufMut, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"hello world").take(2);
+    /// let mut buf = Bytes::from_static(b"hello world").take(2);
     /// let mut dst = vec![];
     ///
-    /// buf.get_mut().set_position(2);
+    /// buf.get_mut().advance(2);
     ///
     /// dst.put(&mut buf);
     /// assert_eq!(*dst, b"ll"[..]);
@@ -94,10 +91,9 @@ impl<T> Take<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use bytes::Buf;
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"hello world").take(2);
+    /// let mut buf = Bytes::from_static(b"hello world").take(2);
     ///
     /// assert_eq!(2, buf.limit());
     /// assert_eq!(b'h', buf.get_u8());
@@ -117,10 +113,9 @@ impl<T> Take<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use bytes::{Buf, BufMut};
-    /// use std::io::Cursor;
+    /// use bytes::{Buf, BufMut, Bytes};
     ///
-    /// let mut buf = Cursor::new(b"hello world").take(2);
+    /// let mut buf = Bytes::from_static(b"hello world").take(2);
     /// let mut dst = vec![];
     ///
     /// dst.put(&mut buf);

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,10 +1,9 @@
-use {IntoBuf, Buf, BufMut};
-use buf::Iter;
+use {Buf, BufMut};
+use buf::IntoIter;
 use debug;
 
 use std::{cmp, fmt, mem, hash, ops, slice, ptr, usize};
 use std::borrow::{Borrow, BorrowMut};
-use std::io::Cursor;
 use std::sync::atomic::{self, AtomicUsize, AtomicPtr};
 use std::sync::atomic::Ordering::{Relaxed, Acquire, Release, AcqRel};
 use std::iter::{FromIterator, Iterator};
@@ -738,22 +737,6 @@ impl Bytes {
         self.inner.truncate(len);
     }
 
-    /// Shortens the buffer, dropping the first `cnt` bytes and keeping the
-    /// rest.
-    ///
-    /// This is the same function as `Buf::advance`, and in the next breaking
-    /// release of `bytes`, this implementation will be removed in favor of
-    /// having `Bytes` implement `Buf`.
-    ///
-    /// # Panics
-    ///
-    /// This function panics if `cnt` is greater than `self.len()`
-    #[inline]
-    pub fn advance(&mut self, cnt: usize) {
-        assert!(cnt <= self.len(), "cannot advance past `remaining`");
-        unsafe { self.inner.set_start(cnt); }
-    }
-
     /// Clears the buffer, removing all data.
     ///
     /// # Examples
@@ -887,21 +870,42 @@ impl Bytes {
             self.extend_from_slice(other_inner.as_ref());
         }
     }
-}
 
-impl IntoBuf for Bytes {
-    type Buf = Cursor<Self>;
-
-    fn into_buf(self) -> Self::Buf {
-        Cursor::new(self)
+    /// Returns an iterator over the bytes contained by the buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::{Buf, IntoBuf, Bytes};
+    ///
+    /// let buf = Bytes::from(&b"abc"[..]);
+    /// let mut iter = buf.iter();
+    ///
+    /// assert_eq!(iter.next().map(|b| *b), Some(b'a'));
+    /// assert_eq!(iter.next().map(|b| *b), Some(b'b'));
+    /// assert_eq!(iter.next().map(|b| *b), Some(b'c'));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn iter<'a>(&'a self) -> ::std::slice::Iter<'a, u8> {
+        self.bytes().iter()
     }
 }
 
-impl<'a> IntoBuf for &'a Bytes {
-    type Buf = Cursor<Self>;
+impl Buf for Bytes {
+    #[inline]
+    fn remaining(&self) -> usize {
+        self.len()
+    }
 
-    fn into_buf(self) -> Self::Buf {
-        Cursor::new(self)
+    #[inline]
+    fn bytes(&self) -> &[u8] {
+        &(self.inner.as_ref())
+    }
+
+    #[inline]
+    fn advance(&mut self, cnt: usize) {
+        assert!(cnt <= self.inner.as_ref().len(), "cannot advance past `remaining`");
+        unsafe { self.inner.set_start(cnt); }
     }
 }
 
@@ -1047,19 +1051,19 @@ impl Borrow<[u8]> for Bytes {
 
 impl IntoIterator for Bytes {
     type Item = u8;
-    type IntoIter = Iter<Cursor<Bytes>>;
+    type IntoIter = IntoIter<Bytes>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.into_buf().iter()
+        IntoIter::new(self)
     }
 }
 
-impl<'a> IntoIterator for &'a Bytes {
+impl<'a> IntoIterator for &'a mut Bytes {
     type Item = u8;
-    type IntoIter = Iter<Cursor<&'a Bytes>>;
+    type IntoIter = IntoIter<&'a mut Bytes>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.into_buf().iter()
+        IntoIter::new(self)
     }
 }
 
@@ -1294,22 +1298,16 @@ impl BytesMut {
     /// let mut buf = BytesMut::with_capacity(1024);
     /// buf.put(&b"hello world"[..]);
     ///
-    /// let other = buf.take();
+    /// let other = buf.split();
     ///
     /// assert!(buf.is_empty());
     /// assert_eq!(1013, buf.capacity());
     ///
     /// assert_eq!(other, b"hello world"[..]);
     /// ```
-    pub fn take(&mut self) -> BytesMut {
+    pub fn split(&mut self) -> BytesMut {
         let len = self.len();
         self.split_to(len)
-    }
-
-    #[deprecated(since = "0.4.1", note = "use take instead")]
-    #[doc(hidden)]
-    pub fn drain(&mut self) -> BytesMut {
-        self.take()
     }
 
     /// Splits the buffer into two at the given index.
@@ -1374,22 +1372,6 @@ impl BytesMut {
     /// [`split_off`]: #method.split_off
     pub fn truncate(&mut self, len: usize) {
         self.inner.truncate(len);
-    }
-
-    /// Shortens the buffer, dropping the first `cnt` bytes and keeping the
-    /// rest.
-    ///
-    /// This is the same function as `Buf::advance`, and in the next breaking
-    /// release of `bytes`, this implementation will be removed in favor of
-    /// having `BytesMut` implement `Buf`.
-    ///
-    /// # Panics
-    ///
-    /// This function panics if `cnt` is greater than `self.len()`
-    #[inline]
-    pub fn advance(&mut self, cnt: usize) {
-        assert!(cnt <= self.len(), "cannot advance past `remaining`");
-        unsafe { self.inner.set_start(cnt); }
     }
 
     /// Clears the buffer, removing all data.
@@ -1501,7 +1483,7 @@ impl BytesMut {
     /// buf.put(&[0; 64][..]);
     ///
     /// let ptr = buf.as_ptr();
-    /// let other = buf.take();
+    /// let other = buf.split();
     ///
     /// assert!(buf.is_empty());
     /// assert_eq!(buf.capacity(), 64);
@@ -1570,6 +1552,43 @@ impl BytesMut {
             self.extend_from_slice(other_inner.as_ref());
         }
     }
+
+    /// Returns an iterator over the bytes contained by the buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::{Buf, BytesMut};
+    ///
+    /// let buf = BytesMut::from(&b"abc"[..]);
+    /// let mut iter = buf.iter();
+    ///
+    /// assert_eq!(iter.next().map(|b| *b), Some(b'a'));
+    /// assert_eq!(iter.next().map(|b| *b), Some(b'b'));
+    /// assert_eq!(iter.next().map(|b| *b), Some(b'c'));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn iter<'a>(&'a self) -> ::std::slice::Iter<'a, u8> {
+        self.bytes().iter()
+    }
+}
+
+impl Buf for BytesMut {
+    #[inline]
+    fn remaining(&self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn bytes(&self) -> &[u8] {
+        &(self.inner.as_ref())
+    }
+
+    #[inline]
+    fn advance(&mut self, cnt: usize) {
+        assert!(cnt <= self.inner.as_ref().len(), "cannot advance past `remaining`");
+        unsafe { self.inner.set_start(cnt); }
+    }
 }
 
 impl BufMut for BytesMut {
@@ -1614,22 +1633,6 @@ impl BufMut for BytesMut {
     #[inline]
     fn put_i8(&mut self, n: i8) {
         self.put_u8(n as u8);
-    }
-}
-
-impl IntoBuf for BytesMut {
-    type Buf = Cursor<Self>;
-
-    fn into_buf(self) -> Self::Buf {
-        Cursor::new(self)
-    }
-}
-
-impl<'a> IntoBuf for &'a BytesMut {
-    type Buf = Cursor<&'a BytesMut>;
-
-    fn into_buf(self) -> Self::Buf {
-        Cursor::new(self)
     }
 }
 
@@ -1797,19 +1800,19 @@ impl Clone for BytesMut {
 
 impl IntoIterator for BytesMut {
     type Item = u8;
-    type IntoIter = Iter<Cursor<BytesMut>>;
+    type IntoIter = IntoIter<BytesMut>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.into_buf().iter()
+        IntoIter::new(self)
     }
 }
 
-impl<'a> IntoIterator for &'a BytesMut {
+impl<'a> IntoIterator for &'a mut BytesMut {
     type Item = u8;
-    type IntoIter = Iter<Cursor<&'a BytesMut>>;
+    type IntoIter = IntoIter<&'a mut BytesMut>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.into_buf().iter()
+        IntoIter::new(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,12 @@
 //! buf.put(&b"hello world"[..]);
 //! buf.put_u16(1234);
 //!
-//! let a = buf.take();
+//! let a = buf.split();
 //! assert_eq!(a, b"hello world\x04\xD2"[..]);
 //!
 //! buf.put(&b"goodbye world"[..]);
 //!
-//! let b = buf.take();
+//! let b = buf.split();
 //! assert_eq!(b, b"goodbye world"[..]);
 //!
 //! assert_eq!(buf.capacity(), 998);
@@ -79,13 +79,6 @@ pub use buf::{
     Buf,
     BufMut,
     IntoBuf,
-};
-#[deprecated(since = "0.4.1", note = "moved to `buf` module")]
-#[doc(hidden)]
-pub use buf::{
-    Reader,
-    Writer,
-    Take,
 };
 
 mod bytes;

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -40,10 +40,10 @@ fn writing_chained() {
 
 #[test]
 fn iterating_two_bufs() {
-    let a = Cursor::new(Bytes::from(&b"hello"[..]));
-    let b = Cursor::new(Bytes::from(&b"world"[..]));
+    let a = Bytes::from(&b"hello"[..]);
+    let b = Bytes::from(&b"world"[..]);
 
-    let res: Vec<u8> = a.chain(b).iter().collect();
+    let res: Vec<u8> = a.chain(b).into_iter().collect();
     assert_eq!(res, &b"helloworld"[..]);
 }
 

--- a/tests/test_iter.rs
+++ b/tests/test_iter.rs
@@ -1,10 +1,10 @@
 extern crate bytes;
 
-use bytes::{Buf, IntoBuf, Bytes};
+use bytes::{Bytes};
 
 #[test]
 fn iter_len() {
-    let buf = Bytes::from(&b"hello world"[..]).into_buf();
+    let buf = Bytes::from_static(b"hello world");
     let iter = buf.iter();
 
     assert_eq!(iter.size_hint(), (11, Some(11)));
@@ -14,7 +14,7 @@ fn iter_len() {
 
 #[test]
 fn empty_iter_len() {
-    let buf = Bytes::from(&b""[..]).into_buf();
+    let buf = Bytes::from_static(b"");
     let iter = buf.iter();
 
     assert_eq!(iter.size_hint(), (0, Some(0)));

--- a/tests/test_take.rs
+++ b/tests/test_take.rs
@@ -5,7 +5,7 @@ use std::io::Cursor;
 
 #[test]
 fn long_take() {
-    // Tests that take with a size greater than the buffer length will not
+    // Tests that get a take with a size greater than the buffer length will not
     // overrun the buffer. Regression test for #138.
     let buf = Cursor::new(b"hello world").take(100);
     assert_eq!(11, buf.remaining());


### PR DESCRIPTION
- Removes `IntoBuf` for `Bytes` and `BytesMut` (since they now implement `Buf`).
- Renames `BytesMut::take()` to `BytesMut::split()`, due to conflict with `Buf::take(n)`.

Closes #158 

Splitting up #210.