### PR TITLE
Update Bytes to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ exclude       = [
     "test/**/*"
 ]
 categories = ["network-programming", "data-structures"]
+edition = "2018"
 
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ bytes = "0.4.12"
 Next, add this to your crate:
 
 ```rust
-extern crate bytes;
-
 use bytes::{Bytes, BytesMut, Buf, BufMut};
 ```
 

--- a/benches/buf.rs
+++ b/benches/buf.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
+#![deny(warnings, rust_2018_idioms)]
 
-extern crate bytes;
 extern crate test;
 
 use test::Bencher;
@@ -109,7 +109,7 @@ macro_rules! bench {
             b.iter(|| {
                 for i in 0..8 {
                     bufs[i].reset();
-                    let buf: &mut Buf =  &mut bufs[i]; // type erasure
+                    let buf: &mut dyn Buf =  &mut bufs[i]; // type erasure
                     test::black_box(buf.$method($($arg,)*));
                 }
             })
@@ -123,7 +123,7 @@ macro_rules! bench {
             b.iter(|| {
                 for i in 0..8 {
                     let mut buf = &arr[i..];
-                    let buf = &mut buf as &mut Buf; // type erasure
+                    let buf = &mut buf as &mut dyn Buf; // type erasure
                     test::black_box(buf.$method($($arg,)*));
                 }
             })
@@ -136,7 +136,7 @@ macro_rules! bench {
             b.iter(|| {
                 for _ in 0..8 {
                     let mut buf = Some(data);
-                    let buf = &mut buf as &mut Buf; // type erasure
+                    let buf = &mut buf as &mut dyn Buf; // type erasure
                     test::black_box(buf.get_u8());
                 }
             })

--- a/benches/bytes.rs
+++ b/benches/bytes.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
+#![deny(warnings, rust_2018_idioms)]
 
-extern crate bytes;
 extern crate test;
 
 use test::Bencher;
@@ -201,7 +201,7 @@ fn slice_empty(b: &mut Bencher) {
     b.iter(|| {
         let b = Bytes::from(vec![17; 1024]).clone();
         for i in 0..1000 {
-            test::black_box(b.slice(i % 100, i % 100));
+            test::black_box(b.slice(i % 100..i % 100));
         }
     })
 }
@@ -212,7 +212,7 @@ fn slice_short_from_arc(b: &mut Bencher) {
         // `clone` is to convert to ARC
         let b = Bytes::from(vec![17; 1024]).clone();
         for i in 0..1000 {
-            test::black_box(b.slice(1, 2 + i % 10));
+            test::black_box(b.slice(1..2 + i % 10));
         }
     })
 }
@@ -231,7 +231,7 @@ fn slice_avg_le_inline_from_arc(b: &mut Bencher) {
         for i in 0..1000 {
             // [1, INLINE_CAP]
             let len = 1 + i % (INLINE_CAP - 1);
-            test::black_box(b.slice(i % 10, i % 10 + len));
+            test::black_box(b.slice(i % 10..i % 10 + len));
         }
     })
 }
@@ -244,7 +244,7 @@ fn slice_large_le_inline_from_arc(b: &mut Bencher) {
         for i in 0..1000 {
             // [INLINE_CAP - 10, INLINE_CAP]
             let len = INLINE_CAP - 9 + i % 10;
-            test::black_box(b.slice(i % 10, i % 10 + len));
+            test::black_box(b.slice(i % 10..i % 10 + len));
         }
     })
 }

--- a/src/buf/buf.rs
+++ b/src/buf/buf.rs
@@ -916,7 +916,7 @@ pub trait Buf {
     }
 }
 
-impl<'a, T: Buf + ?Sized> Buf for &'a mut T {
+impl<T: Buf + ?Sized> Buf for &mut T {
     fn remaining(&self) -> usize {
         (**self).remaining()
     }
@@ -952,7 +952,7 @@ impl<T: Buf + ?Sized> Buf for Box<T> {
     }
 }
 
-impl<'a> Buf for &'a [u8] {
+impl Buf for &[u8] {
     #[inline]
     fn remaining(&self) -> usize {
         self.len()

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -979,7 +979,7 @@ pub trait BufMut {
     }
 }
 
-impl<'a, T: BufMut + ?Sized> BufMut for &'a mut T {
+impl<T: BufMut + ?Sized> BufMut for &mut T {
     fn remaining_mut(&self) -> usize {
         (**self).remaining_mut()
     }
@@ -1015,7 +1015,7 @@ impl<T: BufMut + ?Sized> BufMut for Box<T> {
     }
 }
 
-impl<'a> BufMut for &'a mut [u8] {
+impl BufMut for &mut [u8] {
     #[inline]
     fn remaining_mut(&self) -> usize {
         self.len()
@@ -1029,7 +1029,7 @@ impl<'a> BufMut for &'a mut [u8] {
     #[inline]
     unsafe fn advance_mut(&mut self, cnt: usize) {
         // Lifetime dance taken from `impl Write for &mut [u8]`.
-        let (_, b) = ::std::mem::replace(self, &mut []).split_at_mut(cnt);
+        let (_, b) = std::mem::replace(self, &mut []).split_at_mut(cnt);
         *self = b;
     }
 }

--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -1,5 +1,5 @@
-use {Buf, BufMut};
-use buf::IntoIter;
+use crate::{Buf, BufMut};
+use crate::buf::IntoIter;
 use std::io::{IoSlice, IoSliceMut};
 
 /// A `Chain` sequences two buffers.

--- a/src/buf/from_buf.rs
+++ b/src/buf/from_buf.rs
@@ -1,4 +1,4 @@
-use {Buf, BufMut, IntoBuf, Bytes, BytesMut};
+use crate::{Buf, BufMut, IntoBuf, Bytes, BytesMut};
 
 /// Conversion from a [`Buf`]
 ///

--- a/src/buf/into_buf.rs
+++ b/src/buf/into_buf.rs
@@ -1,5 +1,5 @@
 use super::{Buf};
-use ::BytesMut;
+use crate::BytesMut;
 
 /// Conversion into a `Buf`
 ///

--- a/src/buf/iter.rs
+++ b/src/buf/iter.rs
@@ -1,4 +1,4 @@
-use Buf;
+use crate::Buf;
 
 /// Iterator over the bytes contained by the buffer.
 ///

--- a/src/buf/reader.rs
+++ b/src/buf/reader.rs
@@ -1,4 +1,4 @@
-use {Buf};
+use crate::{Buf};
 
 use std::{cmp, io};
 

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -1,4 +1,4 @@
-use {Buf};
+use crate::Buf;
 
 use std::cmp;
 

--- a/src/buf/writer.rs
+++ b/src/buf/writer.rs
@@ -1,4 +1,4 @@
-use BufMut;
+use crate::BufMut;
 
 use std::{cmp, io};
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,6 +1,6 @@
-use {Buf, BufMut, IntoBuf};
-use buf::IntoIter;
-use debug;
+use crate::{Buf, BufMut, IntoBuf};
+use crate::buf::IntoIter;
+use crate::debug;
 
 use std::{cmp, fmt, mem, hash, slice, ptr, usize};
 use std::borrow::{Borrow, BorrowMut};
@@ -852,7 +852,7 @@ impl Bytes {
     /// assert_eq!(iter.next().map(|b| *b), Some(b'c'));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn iter<'a>(&'a self) -> ::std::slice::Iter<'a, u8> {
+    pub fn iter<'a>(&'a self) -> std::slice::Iter<'a, u8> {
         self.bytes().iter()
     }
 }
@@ -997,7 +997,7 @@ impl Default for Bytes {
 }
 
 impl fmt::Debug for Bytes {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&debug::BsDebug(&self.inner.as_ref()), fmt)
     }
 }
@@ -1026,7 +1026,7 @@ impl IntoIterator for Bytes {
 
 impl<'a> IntoIterator for &'a Bytes {
     type Item = &'a u8;
-    type IntoIter = ::std::slice::Iter<'a, u8>;
+    type IntoIter = std::slice::Iter<'a, u8>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.as_ref().into_iter()
@@ -1534,7 +1534,7 @@ impl BytesMut {
     /// assert_eq!(iter.next().map(|b| *b), Some(b'c'));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn iter<'a>(&'a self) -> ::std::slice::Iter<'a, u8> {
+    pub fn iter<'a>(&'a self) -> std::slice::Iter<'a, u8> {
         self.bytes().iter()
     }
 }
@@ -1725,7 +1725,7 @@ impl Default for BytesMut {
 }
 
 impl fmt::Debug for BytesMut {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&debug::BsDebug(&self.inner.as_ref()), fmt)
     }
 }
@@ -1761,7 +1761,7 @@ impl fmt::Write for BytesMut {
     }
 
     #[inline]
-    fn write_fmt(&mut self, args: fmt::Arguments) -> fmt::Result {
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> fmt::Result {
         fmt::write(self, args)
     }
 }
@@ -1783,7 +1783,7 @@ impl IntoIterator for BytesMut {
 
 impl<'a> IntoIterator for &'a BytesMut {
     type Item = &'a u8;
-    type IntoIter = ::std::slice::Iter<'a, u8>;
+    type IntoIter = std::slice::Iter<'a, u8>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.as_ref().into_iter()
@@ -2818,25 +2818,25 @@ impl<'a, T: ?Sized> PartialOrd<&'a T> for BytesMut
     }
 }
 
-impl<'a> PartialEq<BytesMut> for &'a [u8] {
+impl PartialEq<BytesMut> for &[u8] {
     fn eq(&self, other: &BytesMut) -> bool {
         *other == *self
     }
 }
 
-impl<'a> PartialOrd<BytesMut> for &'a [u8] {
+impl PartialOrd<BytesMut> for &[u8] {
     fn partial_cmp(&self, other: &BytesMut) -> Option<cmp::Ordering> {
         other.partial_cmp(self)
     }
 }
 
-impl<'a> PartialEq<BytesMut> for &'a str {
+impl PartialEq<BytesMut> for &str {
     fn eq(&self, other: &BytesMut) -> bool {
         *other == *self
     }
 }
 
-impl<'a> PartialOrd<BytesMut> for &'a str {
+impl PartialOrd<BytesMut> for &str {
     fn partial_cmp(&self, other: &BytesMut) -> Option<cmp::Ordering> {
         other.partial_cmp(self)
     }
@@ -2938,25 +2938,25 @@ impl PartialOrd<Bytes> for String {
     }
 }
 
-impl<'a> PartialEq<Bytes> for &'a [u8] {
+impl PartialEq<Bytes> for &[u8] {
     fn eq(&self, other: &Bytes) -> bool {
         *other == *self
     }
 }
 
-impl<'a> PartialOrd<Bytes> for &'a [u8] {
+impl PartialOrd<Bytes> for &[u8] {
     fn partial_cmp(&self, other: &Bytes) -> Option<cmp::Ordering> {
         other.partial_cmp(self)
     }
 }
 
-impl<'a> PartialEq<Bytes> for &'a str {
+impl PartialEq<Bytes> for &str {
     fn eq(&self, other: &Bytes) -> bool {
         *other == *self
     }
 }
 
-impl<'a> PartialOrd<Bytes> for &'a str {
+impl PartialOrd<Bytes> for &str {
     fn partial_cmp(&self, other: &Bytes) -> Option<cmp::Ordering> {
         other.partial_cmp(self)
     }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -12,8 +12,8 @@ use std::fmt;
 /// `BsDebug` is not a part of public API of bytes crate.
 pub struct BsDebug<'a>(pub &'a [u8]);
 
-impl<'a> fmt::Debug for BsDebug<'a> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+impl fmt::Debug for BsDebug<'_> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(fmt, "b\"")?;
         for &c in self.0 {
             // https://doc.rust-lang.org/reference.html#byte-escapes

--- a/src/either.rs
+++ b/src/either.rs
@@ -1,9 +1,7 @@
-extern crate either;
+use crate::{Buf, BufMut};
 
-use {Buf, BufMut};
-
-use self::either::Either;
-use self::either::Either::*;
+use either::Either;
+use either::Either::*;
 use std::io::{IoSlice, IoSliceMut};
 
 impl<L, R> Buf for Either<L, R>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,13 +68,11 @@
 //! perform a syscall, which has the potential of failing. Operations on `Buf`
 //! and `BufMut` are infallible.
 
-#![deny(warnings, missing_docs, missing_debug_implementations)]
+#![deny(warnings, missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![doc(html_root_url = "https://docs.rs/bytes/0.5.0")]
 
-extern crate byteorder;
-
 pub mod buf;
-pub use buf::{
+pub use crate::buf::{
     Buf,
     BufMut,
     IntoBuf,
@@ -82,7 +80,7 @@ pub use buf::{
 
 mod bytes;
 mod debug;
-pub use bytes::{Bytes, BytesMut};
+pub use crate::bytes::{Bytes, BytesMut};
 
 // Optional Serde support
 #[cfg(feature = "serde")]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,7 +1,5 @@
-extern crate serde;
-
 use std::{cmp, fmt};
-use self::serde::{Serialize, Serializer, Deserialize, Deserializer, de};
+use serde::{Serialize, Serializer, Deserialize, Deserializer, de};
 use super::{Bytes, BytesMut};
 
 macro_rules! serde_impl {
@@ -20,7 +18,7 @@ macro_rules! serde_impl {
         impl<'de> de::Visitor<'de> for $visitor_ty {
             type Value = $ty;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("byte array")
             }
 

--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -1,5 +1,4 @@
-extern crate bytes;
-extern crate byteorder;
+#![deny(warnings, rust_2018_idioms)]
 
 use bytes::Buf;
 use std::io::IoSlice;

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -1,5 +1,4 @@
-extern crate bytes;
-extern crate byteorder;
+#![deny(warnings, rust_2018_idioms)]
 
 use bytes::{BufMut, BytesMut};
 use std::usize;

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1,4 +1,4 @@
-extern crate bytes;
+#![deny(warnings, rust_2018_idioms)]
 
 use bytes::{Bytes, BytesMut, Buf, BufMut};
 

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -1,4 +1,4 @@
-extern crate bytes;
+#![deny(warnings, rust_2018_idioms)]
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use bytes::buf::Chain;

--- a/tests/test_debug.rs
+++ b/tests/test_debug.rs
@@ -1,4 +1,4 @@
-extern crate bytes;
+#![deny(warnings, rust_2018_idioms)]
 
 use bytes::Bytes;
 

--- a/tests/test_from_buf.rs
+++ b/tests/test_from_buf.rs
@@ -1,4 +1,4 @@
-extern crate bytes;
+#![deny(warnings, rust_2018_idioms)]
 
 use bytes::{Buf, Bytes, BytesMut};
 

--- a/tests/test_iter.rs
+++ b/tests/test_iter.rs
@@ -1,6 +1,6 @@
-extern crate bytes;
+#![deny(warnings, rust_2018_idioms)]
 
-use bytes::{Bytes};
+use bytes::Bytes;
 
 #[test]
 fn iter_len() {

--- a/tests/test_reader.rs
+++ b/tests/test_reader.rs
@@ -1,4 +1,4 @@
-extern crate bytes;
+#![deny(warnings, rust_2018_idioms)]
 
 use std::io::{BufRead, Read};
 

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "serde")]
+#![deny(warnings, rust_2018_idioms)]
 
-extern crate bytes;
-extern crate serde_test;
 use serde_test::{Token, assert_tokens};
 
 #[test]

--- a/tests/test_take.rs
+++ b/tests/test_take.rs
@@ -1,4 +1,4 @@
-extern crate bytes;
+#![deny(warnings, rust_2018_idioms)]
 
 use bytes::Buf;
 


### PR DESCRIPTION
Now that minimum supported Rust version has become 1.36, we can do this.