### PR TITLE
Provide try_get_* methods for `Buf`

### DIFF
--- a/src/buf/buf.rs
+++ b/src/buf/buf.rs
@@ -15,10 +15,8 @@ pub enum TryGetError {
 impl std::fmt::Display for TryGetError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
-            TryGetError::NotEnoughBytes => write!(f, "Not enough bytes in buffer to read value")?,
+            TryGetError::NotEnoughBytes => write!(f, "Not enough bytes in buffer to read value"),
         }
-
-        Ok(())
     }
 }
 

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -28,6 +28,7 @@ mod vec_deque;
 mod writer;
 
 pub use self::buf::Buf;
+pub use self::buf::TryGetError;
 pub use self::buf_mut::BufMut;
 pub use self::from_buf::FromBuf;
 pub use self::chain::Chain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub use crate::buf::{
     Buf,
     BufMut,
     IntoBuf,
+    TryGetError,
 };
 
 mod bytes;


### PR DESCRIPTION
Add `try_get_*` methods on `Buf` which return error values rather than panicking when there are not enough remaining bytes. This allows for cleaner networking code when dealing with variable-length packets.

Resolves #254.