### PR TITLE
Remove byteorder dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-byteorder = "1.3"
 serde = { version = "1.0", optional = true }
 either = { version = "1.5", default-features = false, optional = true }
 

--- a/src/buf/buf.rs
+++ b/src/buf/buf.rs
@@ -1,20 +1,16 @@
 use super::{IntoBuf, Take, Reader, FromBuf, Chain};
-use byteorder::{BigEndian, ByteOrder, LittleEndian};
 
-use std::{cmp, io::IoSlice, ptr};
+use std::{cmp, io::IoSlice, ptr, mem};
 
 macro_rules! buf_get_impl {
     ($this:ident, $size:expr, $conv:path) => ({
          // try to convert directly from the bytes
-        let ret = {
-            // this Option<ret> trick is to avoid keeping a borrow on self
-            // when advance() is called (mut borrow) and to call bytes() only once
-            if let Some(src) = $this.bytes().get(..($size)) {
-                Some($conv(src))
-            } else {
-                None
-            }
-        };
+         // this Option<ret> trick is to avoid keeping a borrow on self
+         // when advance() is called (mut borrow) and to call bytes() only once
+        let ret =  $this.bytes().get(..($size)).map(|src| unsafe {
+            $conv(*(src as *const _ as *const [_; $size]))
+        });
+
         if let Some(ret) = ret {
              // if the direct conversion was possible, advance and return
             $this.advance($size);
@@ -23,16 +19,25 @@ macro_rules! buf_get_impl {
             // if not we copy the bytes in a temp buffer then convert
             let mut buf = [0; ($size)];
             $this.copy_to_slice(&mut buf); // (do the advance)
-            return $conv(&buf);
+            return $conv(buf);
         }
     });
-    ($this:ident, $buf_size:expr, $conv:path, $len_to_read:expr) => ({
+    (le => $this:ident, $typ:tt, $len_to_read:expr) => ({
+        debug_assert!(mem::size_of::<$typ>() >= $len_to_read);
+
         // The same trick as above does not improve the best case speed.
         // It seems to be linked to the way the method is optimised by the compiler
-        let mut buf = [0; ($buf_size)];
+        let mut buf = [0; (mem::size_of::<$typ>())];
         $this.copy_to_slice(&mut buf[..($len_to_read)]);
-        return $conv(&buf[..($len_to_read)], $len_to_read);
+        return $typ::from_le_bytes(buf);
     });
+    (be => $this:ident, $typ:tt, $len_to_read:expr) => {{
+        debug_assert!(mem::size_of::<$typ>() >= $len_to_read);
+
+        let mut buf = [0; (mem::size_of::<$typ>())];
+        $this.copy_to_slice(&mut buf[mem::size_of::<$typ>()-($len_to_read)..]);
+        return $typ::from_be_bytes(buf);
+    }};
 }
 
 /// Read bytes from a buffer.
@@ -314,7 +319,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_u16(&mut self) -> u16 {
-        buf_get_impl!(self, 2, BigEndian::read_u16);
+        buf_get_impl!(self, 2, u16::from_be_bytes);
     }
 
     /// Gets an unsigned 16 bit integer from `self` in little-endian byte order.
@@ -334,7 +339,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_u16_le(&mut self) -> u16 {
-        buf_get_impl!(self, 2, LittleEndian::read_u16);
+        buf_get_impl!(self, 2, u16::from_le_bytes);
     }
 
     /// Gets a signed 16 bit integer from `self` in big-endian byte order.
@@ -354,7 +359,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_i16(&mut self) -> i16 {
-        buf_get_impl!(self, 2, BigEndian::read_i16);
+        buf_get_impl!(self, 2, i16::from_be_bytes);
     }
 
     /// Gets a signed 16 bit integer from `self` in little-endian byte order.
@@ -374,7 +379,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_i16_le(&mut self) -> i16 {
-        buf_get_impl!(self, 2, LittleEndian::read_i16);
+        buf_get_impl!(self, 2, i16::from_le_bytes);
     }
 
     /// Gets an unsigned 32 bit integer from `self` in the big-endian byte order.
@@ -394,7 +399,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_u32(&mut self) -> u32 {
-        buf_get_impl!(self, 4, BigEndian::read_u32);
+        buf_get_impl!(self, 4, u32::from_be_bytes);
     }
 
     /// Gets an unsigned 32 bit integer from `self` in the little-endian byte order.
@@ -414,7 +419,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_u32_le(&mut self) -> u32 {
-        buf_get_impl!(self, 4, LittleEndian::read_u32);
+        buf_get_impl!(self, 4, u32::from_le_bytes);
     }
 
     /// Gets a signed 32 bit integer from `self` in big-endian byte order.
@@ -434,7 +439,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_i32(&mut self) -> i32 {
-        buf_get_impl!(self, 4, BigEndian::read_i32);
+        buf_get_impl!(self, 4, i32::from_be_bytes);
     }
 
     /// Gets a signed 32 bit integer from `self` in little-endian byte order.
@@ -454,7 +459,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_i32_le(&mut self) -> i32 {
-        buf_get_impl!(self, 4, LittleEndian::read_i32);
+        buf_get_impl!(self, 4, i32::from_le_bytes);
     }
 
     /// Gets an unsigned 64 bit integer from `self` in big-endian byte order.
@@ -474,7 +479,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_u64(&mut self) -> u64 {
-        buf_get_impl!(self, 8, BigEndian::read_u64);
+        buf_get_impl!(self, 8, u64::from_be_bytes);
     }
 
     /// Gets an unsigned 64 bit integer from `self` in little-endian byte order.
@@ -494,7 +499,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_u64_le(&mut self) -> u64 {
-        buf_get_impl!(self, 8, LittleEndian::read_u64);
+        buf_get_impl!(self, 8, u64::from_le_bytes);
     }
 
     /// Gets a signed 64 bit integer from `self` in big-endian byte order.
@@ -514,7 +519,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_i64(&mut self) -> i64 {
-        buf_get_impl!(self, 8, BigEndian::read_i64);
+        buf_get_impl!(self, 8, i64::from_be_bytes);
     }
 
     /// Gets a signed 64 bit integer from `self` in little-endian byte order.
@@ -534,7 +539,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_i64_le(&mut self) -> i64 {
-        buf_get_impl!(self, 8, LittleEndian::read_i64);
+        buf_get_impl!(self, 8, i64::from_le_bytes);
     }
 
     /// Gets an unsigned 128 bit integer from `self` in big-endian byte order.
@@ -554,7 +559,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_u128(&mut self) -> u128 {
-        buf_get_impl!(self, 16, BigEndian::read_u128);
+        buf_get_impl!(self, 16, u128::from_be_bytes);
     }
 
     /// Gets an unsigned 128 bit integer from `self` in little-endian byte order.
@@ -574,7 +579,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_u128_le(&mut self) -> u128 {
-        buf_get_impl!(self, 16, LittleEndian::read_u128);
+        buf_get_impl!(self, 16, u128::from_le_bytes);
     }
 
     /// Gets a signed 128 bit integer from `self` in big-endian byte order.
@@ -594,7 +599,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_i128(&mut self) -> i128 {
-        buf_get_impl!(self, 16, BigEndian::read_i128);
+        buf_get_impl!(self, 16, i128::from_be_bytes);
     }
 
     /// Gets a signed 128 bit integer from `self` in little-endian byte order.
@@ -614,7 +619,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_i128_le(&mut self) -> i128 {
-        buf_get_impl!(self, 16, LittleEndian::read_i128);
+        buf_get_impl!(self, 16, i128::from_le_bytes);
     }
 
     /// Gets an unsigned n-byte integer from `self` in big-endian byte order.
@@ -634,7 +639,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_uint(&mut self, nbytes: usize) -> u64 {
-        buf_get_impl!(self, 8, BigEndian::read_uint, nbytes);
+        buf_get_impl!(be => self, u64, nbytes);
     }
 
     /// Gets an unsigned n-byte integer from `self` in little-endian byte order.
@@ -654,7 +659,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_uint_le(&mut self, nbytes: usize) -> u64 {
-        buf_get_impl!(self, 8, LittleEndian::read_uint, nbytes);
+        buf_get_impl!(le => self, u64, nbytes);
     }
 
     /// Gets a signed n-byte integer from `self` in big-endian byte order.
@@ -674,7 +679,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_int(&mut self, nbytes: usize) -> i64 {
-        buf_get_impl!(self, 8, BigEndian::read_int, nbytes);
+        buf_get_impl!(be => self, i64, nbytes);
     }
 
     /// Gets a signed n-byte integer from `self` in little-endian byte order.
@@ -694,7 +699,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_int_le(&mut self, nbytes: usize) -> i64 {
-        buf_get_impl!(self, 8, LittleEndian::read_int, nbytes);
+        buf_get_impl!(le => self, i64, nbytes);
     }
 
     /// Gets an IEEE754 single-precision (4 bytes) floating point number from
@@ -715,7 +720,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_f32(&mut self) -> f32 {
-        buf_get_impl!(self, 4, BigEndian::read_f32);
+        unsafe { *(&Self::get_u32(self) as *const u32 as *const f32) }
     }
 
     /// Gets an IEEE754 single-precision (4 bytes) floating point number from
@@ -736,7 +741,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_f32_le(&mut self) -> f32 {
-        buf_get_impl!(self, 4, LittleEndian::read_f32);
+        unsafe { *(&Self::get_u32_le(self) as *const u32 as *const f32) }
     }
 
     /// Gets an IEEE754 double-precision (8 bytes) floating point number from
@@ -757,7 +762,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_f64(&mut self) -> f64 {
-        buf_get_impl!(self, 8, BigEndian::read_f64);
+        unsafe { *(&Self::get_u64(self) as *const u64 as *const f64) }
     }
 
     /// Gets an IEEE754 double-precision (8 bytes) floating point number from
@@ -778,7 +783,7 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`.
     fn get_f64_le(&mut self) -> f64 {
-        buf_get_impl!(self, 8, LittleEndian::read_f64);
+        unsafe { *(&Self::get_u64_le(self) as *const u64 as *const f64) }
     }
 
     /// Transforms a `Buf` into a concrete buffer.

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -1,7 +1,6 @@
 use super::{IntoBuf, Writer};
-use byteorder::{LittleEndian, ByteOrder, BigEndian};
 
-use std::{cmp, io::IoSliceMut, ptr, usize};
+use std::{mem, cmp, io::IoSliceMut, ptr, usize};
 
 /// A trait for values that provide sequential write access to bytes.
 ///
@@ -354,9 +353,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_u16(&mut self, n: u16) {
-        let mut buf = [0; 2];
-        BigEndian::write_u16(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_be_bytes())
     }
 
     /// Writes an unsigned 16 bit integer to `self` in little-endian byte order.
@@ -378,9 +375,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_u16_le(&mut self, n: u16) {
-        let mut buf = [0; 2];
-        LittleEndian::write_u16(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_le_bytes())
     }
 
     /// Writes a signed 16 bit integer to `self` in big-endian byte order.
@@ -402,9 +397,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_i16(&mut self, n: i16) {
-        let mut buf = [0; 2];
-        BigEndian::write_i16(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_be_bytes())
     }
 
     /// Writes a signed 16 bit integer to `self` in little-endian byte order.
@@ -426,9 +419,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_i16_le(&mut self, n: i16) {
-        let mut buf = [0; 2];
-        LittleEndian::write_i16(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_le_bytes())
     }
 
     /// Writes an unsigned 32 bit integer to `self` in big-endian byte order.
@@ -450,9 +441,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_u32(&mut self, n: u32) {
-        let mut buf = [0; 4];
-        BigEndian::write_u32(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_be_bytes())
     }
 
     /// Writes an unsigned 32 bit integer to `self` in little-endian byte order.
@@ -474,9 +463,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_u32_le(&mut self, n: u32) {
-        let mut buf = [0; 4];
-        LittleEndian::write_u32(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_le_bytes())
     }
 
     /// Writes a signed 32 bit integer to `self` in big-endian byte order.
@@ -498,9 +485,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_i32(&mut self, n: i32) {
-        let mut buf = [0; 4];
-        BigEndian::write_i32(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_be_bytes())
     }
 
     /// Writes a signed 32 bit integer to `self` in little-endian byte order.
@@ -522,9 +507,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_i32_le(&mut self, n: i32) {
-        let mut buf = [0; 4];
-        LittleEndian::write_i32(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_le_bytes())
     }
 
     /// Writes an unsigned 64 bit integer to `self` in the big-endian byte order.
@@ -546,9 +529,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_u64(&mut self, n: u64) {
-        let mut buf = [0; 8];
-        BigEndian::write_u64(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_be_bytes())
     }
 
     /// Writes an unsigned 64 bit integer to `self` in little-endian byte order.
@@ -570,9 +551,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_u64_le(&mut self, n: u64) {
-        let mut buf = [0; 8];
-        LittleEndian::write_u64(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_le_bytes())
     }
 
     /// Writes a signed 64 bit integer to `self` in the big-endian byte order.
@@ -594,9 +573,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_i64(&mut self, n: i64) {
-        let mut buf = [0; 8];
-        BigEndian::write_i64(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_be_bytes())
     }
 
     /// Writes a signed 64 bit integer to `self` in little-endian byte order.
@@ -618,9 +595,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_i64_le(&mut self, n: i64) {
-        let mut buf = [0; 8];
-        LittleEndian::write_i64(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_le_bytes())
     }
 
     /// Writes an unsigned 128 bit integer to `self` in the big-endian byte order.
@@ -642,9 +617,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_u128(&mut self, n: u128) {
-        let mut buf = [0; 16];
-        BigEndian::write_u128(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_be_bytes())
     }
 
     /// Writes an unsigned 128 bit integer to `self` in little-endian byte order.
@@ -666,9 +639,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_u128_le(&mut self, n: u128) {
-        let mut buf = [0; 16];
-        LittleEndian::write_u128(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_le_bytes())
     }
 
     /// Writes a signed 128 bit integer to `self` in the big-endian byte order.
@@ -690,9 +661,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_i128(&mut self, n: i128) {
-        let mut buf = [0; 16];
-        BigEndian::write_i128(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_be_bytes())
     }
 
     /// Writes a signed 128 bit integer to `self` in little-endian byte order.
@@ -714,9 +683,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_i128_le(&mut self, n: i128) {
-        let mut buf = [0; 16];
-        LittleEndian::write_i128(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_slice(&n.to_le_bytes())
     }
 
     /// Writes an unsigned n-byte integer to `self` in big-endian byte order.
@@ -738,9 +705,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_uint(&mut self, n: u64, nbytes: usize) {
-        let mut buf = [0; 8];
-        BigEndian::write_uint(&mut buf, n, nbytes);
-        self.put_slice(&buf[0..nbytes])
+        self.put_slice(&n.to_be_bytes()[mem::size_of_val(&n) - nbytes..]);
     }
 
     /// Writes an unsigned n-byte integer to `self` in the little-endian byte order.
@@ -762,9 +727,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_uint_le(&mut self, n: u64, nbytes: usize) {
-        let mut buf = [0; 8];
-        LittleEndian::write_uint(&mut buf, n, nbytes);
-        self.put_slice(&buf[0..nbytes])
+        self.put_slice(&n.to_le_bytes()[0..nbytes]);
     }
 
     /// Writes a signed n-byte integer to `self` in big-endian byte order.
@@ -786,9 +749,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_int(&mut self, n: i64, nbytes: usize) {
-        let mut buf = [0; 8];
-        BigEndian::write_int(&mut buf, n, nbytes);
-        self.put_slice(&buf[0..nbytes])
+        self.put_slice(&n.to_be_bytes()[mem::size_of_val(&n) - nbytes..]);
     }
 
     /// Writes a signed n-byte integer to `self` in little-endian byte order.
@@ -810,9 +771,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_int_le(&mut self, n: i64, nbytes: usize) {
-        let mut buf = [0; 8];
-        LittleEndian::write_int(&mut buf, n, nbytes);
-        self.put_slice(&buf[0..nbytes])
+        self.put_slice(&n.to_le_bytes()[0..nbytes]);
     }
 
     /// Writes  an IEEE754 single-precision (4 bytes) floating point number to
@@ -835,9 +794,9 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_f32(&mut self, n: f32) {
-        let mut buf = [0; 4];
-        BigEndian::write_f32(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_u32(unsafe {
+            *(&n as *const f32 as *const u32)
+        })
     }
 
     /// Writes  an IEEE754 single-precision (4 bytes) floating point number to
@@ -860,9 +819,9 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_f32_le(&mut self, n: f32) {
-        let mut buf = [0; 4];
-        LittleEndian::write_f32(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_u32_le(unsafe {
+            *(&n as *const f32 as *const u32)
+        })
     }
 
     /// Writes  an IEEE754 double-precision (8 bytes) floating point number to
@@ -885,9 +844,9 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_f64(&mut self, n: f64) {
-        let mut buf = [0; 8];
-        BigEndian::write_f64(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_u64(unsafe {
+            *(&n as *const f64 as *const u64)
+        })
     }
 
     /// Writes  an IEEE754 double-precision (8 bytes) floating point number to
@@ -910,9 +869,9 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_f64_le(&mut self, n: f64) {
-        let mut buf = [0; 8];
-        LittleEndian::write_f64(&mut buf, n);
-        self.put_slice(&buf)
+        self.put_u64_le(unsafe {
+            *(&n as *const f64 as *const u64)
+        })
     }
 
     /// Creates a "by reference" adaptor for this instance of `BufMut`.

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -794,9 +794,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_f32(&mut self, n: f32) {
-        self.put_u32(unsafe {
-            *(&n as *const f32 as *const u32)
-        })
+        self.put_u32(n.to_bits());
     }
 
     /// Writes  an IEEE754 single-precision (4 bytes) floating point number to
@@ -819,9 +817,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_f32_le(&mut self, n: f32) {
-        self.put_u32_le(unsafe {
-            *(&n as *const f32 as *const u32)
-        })
+        self.put_u32_le(n.to_bits());
     }
 
     /// Writes  an IEEE754 double-precision (8 bytes) floating point number to
@@ -844,9 +840,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_f64(&mut self, n: f64) {
-        self.put_u64(unsafe {
-            *(&n as *const f64 as *const u64)
-        })
+        self.put_u64(n.to_bits());
     }
 
     /// Writes  an IEEE754 double-precision (8 bytes) floating point number to
@@ -869,9 +863,7 @@ pub trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     fn put_f64_le(&mut self, n: f64) {
-        self.put_u64_le(unsafe {
-            *(&n as *const f64 as *const u64)
-        })
+        self.put_u64_le(n.to_bits());
     }
 
     /// Creates a "by reference" adaptor for this instance of `BufMut`.


### PR DESCRIPTION
This what it takes to remove the dependency.
It is a bit difficult to make it generic to retrieve le/be from array because std methods only allow plain sized array.
But it shouldn't be performance hit because byteorder copies slices always

Fixes #279