### PR TITLE
adding impl for std::ops::BitXor

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -9,6 +9,7 @@ use core::sync::atomic::Ordering::{Relaxed, Acquire, Release, AcqRel};
 use core::iter::{FromIterator, Iterator};
 
 use alloc::{vec::Vec, string::String, boxed::Box, borrow::{Borrow, BorrowMut}};
+use std::ops::BitXor;
 
 /// A reference counted contiguous slice of memory.
 ///
@@ -2989,6 +2990,15 @@ impl PartialEq<Bytes> for BytesMut
 {
     fn eq(&self, other: &Bytes) -> bool {
         &other[..] == &self[..]
+    }
+}
+
+impl BitXor for Bytes {
+    type Output = Option<Self>; //none when rhs length not the same as self length
+
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        if self.len() != rhs.len() { return None; }
+        Some(self.iter().zip(rhs.iter()).map( |(l,r)| *l ^ *r ).collect())
     }
 }
 

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -840,6 +840,26 @@ fn from_iter_no_size_hint() {
     assert_eq!(&actual[..], &expect[..]);
 }
 
+#[test]
+fn bytes_xor_success() {
+    let left = &[0x01,0x01,0x00,0x00];
+    let right = &[0x00,0x01,0x00,0x01];
+    let expect = &[0x01,0x00,0x00,0x01];
+    assert_eq!(Bytes::from_static(left) ^ Bytes::from_static(right), Some(Bytes::from_static(expect)));
+    // xor is commutative
+    assert_eq!(Bytes::from_static(right) ^ Bytes::from_static(left), Some(Bytes::from_static(expect)));
+}
+
+#[test]
+fn bytes_xor_zero_lengths_return_zero() {
+    assert_eq!(Bytes::new() ^ Bytes::new(), Some(Bytes::new()));
+}
+
+#[test]
+fn bytes_xor_different_lengths_returns_none() {
+    assert_eq!(Bytes::from_static(&[0x01,0x01,0x00,0x00,0x00]) ^ Bytes::from_static(&[0x00,0x01,0x00,0x01]), None);
+}
+
 fn test_slice_ref(bytes: &Bytes, start: usize, end: usize, expected: &[u8]) {
     let slice = &(bytes.as_ref()[start..end]);
     let sub = bytes.slice_ref(&slice);


### PR DESCRIPTION
An impl of bit-wise xor of two Bytes, returning None if both Bytes are not of the same length.