### PR TITLE
Remove Buf impl for &str

### DIFF
--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -903,9 +903,9 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Buf};
+    /// use bytes::Buf;
     ///
-    /// let bytes = "hello world".to_bytes();
+    /// let bytes = (&b"hello world"[..]).to_bytes();
     /// assert_eq!(&bytes[..], &b"hello world"[..]);
     /// ```
     fn to_bytes(&mut self) -> crate::Bytes {
@@ -963,23 +963,6 @@ impl Buf for &[u8] {
     #[inline]
     fn bytes(&self) -> &[u8] {
         self
-    }
-
-    #[inline]
-    fn advance(&mut self, cnt: usize) {
-        *self = &self[cnt..];
-    }
-}
-
-impl Buf for &str {
-    #[inline]
-    fn remaining(&self) -> usize {
-        self.len()
-    }
-
-    #[inline]
-    fn bytes(&self) -> &[u8] {
-        self.as_bytes()
     }
 
     #[inline]

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -24,7 +24,7 @@ use alloc::{vec::Vec, boxed::Box};
 ///
 /// let mut buf = vec![];
 ///
-/// buf.put("hello world");
+/// buf.put(&b"hello world"[..]);
 ///
 /// assert_eq!(buf, b"hello world");
 /// ```
@@ -44,7 +44,7 @@ pub trait BufMut {
     /// let mut buf = &mut dst[..];
     ///
     /// let original_remaining = buf.remaining_mut();
-    /// buf.put("hello");
+    /// buf.put(&b"hello"[..]);
     ///
     /// assert_eq!(original_remaining - 5, buf.remaining_mut());
     /// ```
@@ -114,7 +114,7 @@ pub trait BufMut {
     ///
     /// assert!(buf.has_remaining_mut());
     ///
-    /// buf.put("hello");
+    /// buf.put(&b"hello"[..]);
     ///
     /// assert!(!buf.has_remaining_mut());
     /// ```
@@ -217,7 +217,7 @@ pub trait BufMut {
     ///
     /// buf.put_u8(b'h');
     /// buf.put(&b"ello"[..]);
-    /// buf.put(" world");
+    /// buf.put(&b" world"[..]);
     ///
     /// assert_eq!(buf, b"hello world");
     /// ```

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -38,7 +38,7 @@ use crate::loom::sync::atomic::{self, AtomicPtr, AtomicUsize, Ordering};
 ///
 /// buf.put_u8(b'h');
 /// buf.put_u8(b'e');
-/// buf.put("llo");
+/// buf.put(&b"llo"[..]);
 ///
 /// assert_eq!(&buf[..], b"hello");
 ///
@@ -219,7 +219,7 @@ impl BytesMut {
     /// use std::thread;
     ///
     /// let mut b = BytesMut::with_capacity(64);
-    /// b.put("hello world");
+    /// b.put(&b"hello world"[..]);
     /// let b1 = b.freeze();
     /// let b2 = b1.clone();
     ///

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -402,7 +402,7 @@ fn reserve_vec_recycling() {
     let mut bytes = BytesMut::with_capacity(16);
     assert_eq!(bytes.capacity(), 16);
     let addr = bytes.as_ptr() as usize;
-    bytes.put("0123456789012345");
+    bytes.put("0123456789012345".as_bytes());
     assert_eq!(bytes.as_ptr() as usize, addr);
     bytes.advance(10);
     assert_eq!(bytes.capacity(), 6);


### PR DESCRIPTION
A `&str` cannot arbitrarily advance bytes, since it will panic if
advanced to the middle of a Unicode segment.