### PR TITLE
Change BufMut methods that expose maybe-uninitialized bytes

### DIFF
--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -1,8 +1,12 @@
 use crate::{Buf, BufMut};
 use crate::buf::IntoIter;
 
+use core::mem::MaybeUninit;
+
 #[cfg(feature = "std")]
-use std::io::{IoSlice, IoSliceMut};
+use std::io::{IoSlice};
+#[cfg(feature = "std")]
+use crate::buf::IoSliceMut;
 
 /// A `Chain` sequences two buffers.
 ///
@@ -196,7 +200,7 @@ impl<T, U> BufMut for Chain<T, U>
         self.a.remaining_mut() + self.b.remaining_mut()
     }
 
-    unsafe fn bytes_mut(&mut self) -> &mut [u8] {
+    fn bytes_mut(&mut self) -> &mut [MaybeUninit<u8>] {
         if self.a.has_remaining_mut() {
             self.a.bytes_mut()
         } else {
@@ -223,7 +227,7 @@ impl<T, U> BufMut for Chain<T, U>
     }
 
     #[cfg(feature = "std")]
-    unsafe fn bytes_vectored_mut<'a>(&'a mut self, dst: &mut [IoSliceMut<'a>]) -> usize {
+    fn bytes_vectored_mut<'a>(&'a mut self, dst: &mut [IoSliceMut<'a>]) -> usize {
         let mut n = self.a.bytes_vectored_mut(dst);
         n += self.b.bytes_vectored_mut(&mut dst[n..]);
         n

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -31,6 +31,8 @@ mod writer;
 
 pub use self::buf_impl::Buf;
 pub use self::buf_mut::BufMut;
+#[cfg(feature = "std")]
+pub use self::buf_mut::IoSliceMut;
 pub use self::chain::Chain;
 pub use self::iter::IntoIter;
 #[cfg(feature = "std")]

--- a/src/either.rs
+++ b/src/either.rs
@@ -4,7 +4,9 @@ use either::Either;
 use either::Either::*;
 
 #[cfg(feature = "std")]
-use std::io::{IoSlice, IoSliceMut};
+use std::io::IoSlice;
+#[cfg(feature = "std")]
+use crate::buf::IoSliceMut;
 
 impl<L, R> Buf for Either<L, R>
 where
@@ -60,7 +62,7 @@ where
         }
     }
 
-    unsafe fn bytes_mut(&mut self) -> &mut [u8] {
+    fn bytes_mut(&mut self) -> &mut [core::mem::MaybeUninit<u8>] {
         match *self {
             Left(ref mut b) => b.bytes_mut(),
             Right(ref mut b) => b.bytes_mut(),
@@ -68,7 +70,7 @@ where
     }
 
     #[cfg(feature = "std")]
-    unsafe fn bytes_vectored_mut<'a>(&'a mut self, dst: &mut [IoSliceMut<'a>]) -> usize {
+    fn bytes_vectored_mut<'a>(&'a mut self, dst: &mut [IoSliceMut<'a>]) -> usize {
         match *self {
             Left(ref mut b) => b.bytes_vectored_mut(dst),
             Right(ref mut b) => b.bytes_vectored_mut(dst),

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -1,9 +1,8 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use bytes::{BufMut, BytesMut};
+use bytes::{buf::IoSliceMut, BufMut, BytesMut};
 use std::usize;
 use std::fmt::Write;
-use std::io::IoSliceMut;
 
 #[test]
 fn test_vec_as_mut_buf() {
@@ -11,9 +10,7 @@ fn test_vec_as_mut_buf() {
 
     assert_eq!(buf.remaining_mut(), usize::MAX);
 
-    unsafe {
-        assert!(buf.bytes_mut().len() >= 64);
-    }
+    assert!(buf.bytes_mut().len() >= 64);
 
     buf.put(&b"zomg"[..]);
 
@@ -72,20 +69,16 @@ fn test_clone() {
 fn test_bufs_vec_mut() {
     let b1: &mut [u8] = &mut [];
     let b2: &mut [u8] = &mut [];
-    let mut dst = [IoSliceMut::new(b1), IoSliceMut::new(b2)];
+    let mut dst = [IoSliceMut::from(b1), IoSliceMut::from(b2)];
 
     // with no capacity
     let mut buf = BytesMut::new();
     assert_eq!(buf.capacity(), 0);
-    unsafe {
-        assert_eq!(0, buf.bytes_vectored_mut(&mut dst[..]));
-    }
+    assert_eq!(0, buf.bytes_vectored_mut(&mut dst[..]));
 
     // with capacity
     let mut buf = BytesMut::with_capacity(64);
-    unsafe {
-        assert_eq!(1, buf.bytes_vectored_mut(&mut dst[..]));
-    }
+    assert_eq!(1, buf.bytes_vectored_mut(&mut dst[..]));
 }
 
 #[test]

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -465,6 +465,16 @@ fn extend_from_slice_mut() {
 }
 
 #[test]
+fn extend_mut_without_size_hint() {
+    let mut bytes = BytesMut::with_capacity(0);
+    let mut long_iter = LONG.iter();
+
+    // Use iter::from_fn since it doesn't know a size_hint
+    bytes.extend(std::iter::from_fn(|| long_iter.next()));
+    assert_eq!(*bytes, LONG[..]);
+}
+
+#[test]
 fn from_static() {
     let mut a = Bytes::from_static(b"ab");
     let b = a.split_off(1);


### PR DESCRIPTION
- The return type of `BufMut::bytes_mut` is now
  `&mut [MaybeUninit<u8>]`.
- The argument type of `BufMut::bytes_vectored_mut` is now
  `&mut [bytes::buf::IoSliceMut]`.
- `bytes::buf::IoSliceMut` is a `repr(transparent)` wrapper around an
  `std::io::IoSliceMut`, but does not expose the inner bytes with a safe
  API, since they might be uninitialized.
- `BufMut::bytesMut` and `BufMut::bytes_vectored_mut` are no longer
  `unsafe fn`, since the types encapsulate the unsafety instead.