### PR TITLE
Make Bytes::from_static a const fn?

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
 - template: ci/azure-test-stable.yml
   parameters:
     name: minrust
-    rust_version: 1.36.0
+    rust_version: 1.39.0
     cmd: check
 
 # Stable
@@ -37,7 +37,7 @@ jobs:
   parameters:
     name: nightly
     # Pin nightly to avoid being impacted by breakage
-    rust_version: nightly-2019-07-17
+    rust_version: nightly-2019-09-25
     benches: true
 
 # Run tests on some extra platforms

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -114,6 +114,17 @@ impl Bytes {
     /// assert_eq!(&b[..], b"hello");
     /// ```
     #[inline]
+    #[cfg(not(all(loom, test)))]
+    pub const fn from_static(bytes: &'static [u8]) -> Bytes {
+        Bytes {
+            ptr: bytes.as_ptr(),
+            len: bytes.len(),
+            data: AtomicPtr::new(ptr::null_mut()),
+            vtable: &STATIC_VTABLE,
+        }
+    }
+
+    #[cfg(all(loom, test))]
     pub fn from_static(bytes: &'static [u8]) -> Bytes {
         Bytes {
             ptr: bytes.as_ptr(),
@@ -732,7 +743,7 @@ impl fmt::Debug for Vtable {
 
 // ===== impl StaticVtable =====
 
-static STATIC_VTABLE: Vtable = Vtable {
+const STATIC_VTABLE: Vtable = Vtable {
     clone: static_clone,
     drop: static_drop,
 };


### PR DESCRIPTION
I think it'd be useful to make `Bytes::from_static` a const fn so that `Bytes` and types built on `Bytes` can be used in consts and statics. This would require a minimum Rust version of 1.39 though. (Opened a PR to discuss this instead of an issue because it's a two line change.)