### PR TITLE
Minimal versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ features = ["i128"]
 
 [dependencies]
 byteorder = "1.1.0"
-iovec = "0.1"
+iovec = "0.1.5"
 serde = { version = "1.0", optional = true }
 either = { version = "1.5", default-features = false, optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //! perform a syscall, which has the potential of failing. Operations on `Buf`
 //! and `BufMut` are infallible.
 
-#![deny(warnings, missing_docs, missing_debug_implementations)]
+#![deny(missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/bytes/0.4.12")]
 
 extern crate byteorder;


### PR DESCRIPTION
---
Requires a release of https://github.com/carllerche/iovec/pull/28