### PR TITLE
Improve performance of `BytesMut::reserve`

### DIFF
--- a/benches/bytes_mut.rs
+++ b/benches/bytes_mut.rs
@@ -141,10 +141,25 @@ fn fmt_write(b: &mut Bencher) {
     })
 }
 
+#[bench]
+fn bytes_mut_extend(b: &mut Bencher) {
+    let mut buf = BytesMut::with_capacity(256);
+    let data = [33u8; 32];
+
+    b.bytes = data.len() as u64 * 4;
+    b.iter(|| {
+        for _ in 0..4 {
+            buf.extend(&data);
+        }
+        test::black_box(&buf);
+        unsafe { buf.set_len(0); }
+    });
+}
+
 // BufMut for BytesMut vs Vec<u8>
 
 #[bench]
-fn put_bytes_mut(b: &mut Bencher) {
+fn put_slice_bytes_mut(b: &mut Bencher) {
     let mut buf = BytesMut::with_capacity(256);
     let data = [33u8; 32];
 
@@ -174,7 +189,7 @@ fn put_u8_bytes_mut(b: &mut Bencher) {
 }
 
 #[bench]
-fn put_vec(b: &mut Bencher) {
+fn put_slice_vec(b: &mut Bencher) {
     let mut buf = Vec::<u8>::with_capacity(256);
     let data = [33u8; 32];
 
@@ -204,7 +219,7 @@ fn put_u8_vec(b: &mut Bencher) {
 }
 
 #[bench]
-fn put_vec_extend(b: &mut Bencher) {
+fn put_slice_vec_extend(b: &mut Bencher) {
     let mut buf = Vec::<u8>::with_capacity(256);
     let data = [33u8; 32];
 

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -513,6 +513,7 @@ impl BytesMut {
     /// # Panics
     ///
     /// Panics if the new capacity overflows `usize`.
+    #[inline]
     pub fn reserve(&mut self, additional: usize) {
         let len = self.len();
         let rem = self.capacity() - len;
@@ -523,6 +524,13 @@ impl BytesMut {
             return;
         }
 
+        self.reserve_inner(additional);
+    }
+
+    // In separate function to allow the short-circuits in `reserve` to
+    // be inline-able. Significant helps performance.
+    fn reserve_inner(&mut self, additional: usize) {
+        let len = self.len();
         let kind = self.kind();
 
         if kind == KIND_VEC {
@@ -637,6 +645,7 @@ impl BytesMut {
 
         // Forget the vector handle
         mem::forget(v);
+
     }
     /// Appends given bytes to this object.
     ///


### PR DESCRIPTION
Makes the short-circuit checks inline-able, and the moves the actual
reserving code to an inner function.

On my machine, the `bytes_mut_extend` benchmark improves from 126 MB/s to 173 MB/s.