### PR TITLE
implicitly grow BytesMut; add BufMutExt::chain_mut

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
   parameters:
     name: nightly
     # Pin nightly to avoid being impacted by breakage
-    rust_version: nightly-2019-11-20
+    rust_version: nightly-2019-09-25
     benches: true
 
 # Run tests on some extra platforms

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
 - template: ci/azure-test-stable.yml
   parameters:
     name: minrust
-    rust_version: 1.36.0
+    rust_version: 1.39.0
     cmd: check
 
 # Stable
@@ -37,7 +37,7 @@ jobs:
   parameters:
     name: nightly
     # Pin nightly to avoid being impacted by breakage
-    rust_version: nightly-2019-07-17
+    rust_version: nightly-2019-11-20
     benches: true
 
 # Run tests on some extra platforms

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -270,7 +270,7 @@ pub trait BufMut {
     fn put_slice(&mut self, src: &[u8]) {
         let mut off = 0;
 
-        assert!(self.remaining_mut() >= src.len(), "buffer overflow");
+        assert!(self.remaining_mut() >= src.len(), "buffer overflow; remaining = {}; src = {}", self.remaining_mut(), src.len());
 
         while off < src.len() {
             let cnt;

--- a/src/buf/ext/mod.rs
+++ b/src/buf/ext/mod.rs
@@ -124,6 +124,32 @@ pub trait BufMutExt: BufMut {
     fn writer(self) -> Writer<Self> where Self: Sized {
         writer::new(self)
     }
+
+    /// Creates an adaptor which will chain this buffer with another.
+    ///
+    /// The returned `BufMut` instance will first write to all bytes from
+    /// `self`. Afterwards, it will write to `next`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::{BufMut, buf::BufMutExt};
+    ///
+    /// let mut a = [0u8; 5];
+    /// let mut b = [0u8; 6];
+    ///
+    /// let mut chain = (&mut a[..]).chain_mut(&mut b[..]);
+    ///
+    /// chain.put_slice(b"hello world");
+    ///
+    /// assert_eq!(&a[..], b"hello");
+    /// assert_eq!(&b[..], b" world");
+    /// ```
+    fn chain_mut<U: BufMut>(self, next: U) -> Chain<Self, U>
+        where Self: Sized
+    {
+        Chain::new(self, next)
+    }
 }
 
 impl<B: BufMut + ?Sized> BufMutExt for B {}

--- a/src/buf/ext/mod.rs
+++ b/src/buf/ext/mod.rs
@@ -125,7 +125,7 @@ pub trait BufMutExt: BufMut {
         writer::new(self)
     }
 
-    /// Creates an adaptor which will chain this buffer with another.
+    /// Creates an adapter which will chain this buffer with another.
     ///
     /// The returned `BufMut` instance will first write to all bytes from
     /// `self`. Afterwards, it will write to `next`.

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -924,7 +924,7 @@ impl Buf for BytesMut {
 impl BufMut for BytesMut {
     #[inline]
     fn remaining_mut(&self) -> usize {
-        self.capacity() - self.len()
+        usize::MAX - self.len()
     }
 
     #[inline]
@@ -936,6 +936,10 @@ impl BufMut for BytesMut {
 
     #[inline]
     fn bytes_mut(&mut self) -> &mut [mem::MaybeUninit<u8>] {
+        if self.capacity() == self.len() {
+            self.reserve(64);
+        }
+
         unsafe {
             slice::from_raw_parts_mut(self.ptr.as_ptr().offset(self.len as isize) as *mut mem::MaybeUninit<u8>, self.cap)
         }

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -930,7 +930,7 @@ impl BufMut for BytesMut {
     #[inline]
     unsafe fn advance_mut(&mut self, cnt: usize) {
         let new_len = self.len() + cnt;
-        assert!(new_len <= self.cap);
+        assert!(new_len <= self.cap, "new_len = {}; capacity = {}", new_len, self.cap);
         self.len = new_len;
     }
 
@@ -941,7 +941,7 @@ impl BufMut for BytesMut {
         }
 
         unsafe {
-            slice::from_raw_parts_mut(self.ptr.as_ptr().offset(self.len as isize) as *mut mem::MaybeUninit<u8>, self.cap)
+            slice::from_raw_parts_mut(self.ptr.as_ptr().offset(self.len as isize) as *mut mem::MaybeUninit<u8>, self.cap - self.len)
         }
     }
 }

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -941,7 +941,10 @@ impl BufMut for BytesMut {
         }
 
         unsafe {
-            slice::from_raw_parts_mut(self.ptr.as_ptr().offset(self.len as isize) as *mut mem::MaybeUninit<u8>, self.cap - self.len)
+            let ptr = self.ptr.as_ptr().offset(self.len as isize);
+            let len = self.cap - self.len
+
+            slice::from_raw_parts_mut(ptr as *mut mem::MaybeUninit<u8>, len)
         }
     }
 }

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -74,7 +74,7 @@ fn test_bufs_vec_mut() {
     // with no capacity
     let mut buf = BytesMut::new();
     assert_eq!(buf.capacity(), 0);
-    assert_eq!(0, buf.bytes_vectored_mut(&mut dst[..]));
+    assert_eq!(1, buf.bytes_vectored_mut(&mut dst[..]));
 
     // with capacity
     let mut buf = BytesMut::with_capacity(64);

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -93,8 +93,8 @@ fn fmt_write() {
 
 
     let mut c = BytesMut::with_capacity(64);
-    write!(c, "{}", s).unwrap_err();
-    assert!(c.is_empty());
+    write!(c, "{}", s).unwrap();
+    assert_eq!(c, s[..].as_bytes());
 }
 
 #[test]

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -820,3 +820,25 @@ fn empty_slice_ref_catches_not_an_empty_subset() {
 
     bytes.slice_ref(slice);
 }
+
+#[test]
+fn bytes_buf_mut_advance() {
+    let mut bytes = BytesMut::with_capacity(1024);
+
+    unsafe {
+        let ptr = bytes.bytes_mut().as_ptr();
+        assert_eq!(1024, bytes.bytes_mut().len());
+
+        bytes.advance_mut(10);
+
+        let next = bytes.bytes_mut().as_ptr();
+        assert_eq!(1024 - 10, bytes.bytes_mut().len());
+        assert_eq!(ptr.offset(10), next);
+
+        // advance to the end
+        bytes.advance_mut(1024 - 10);
+
+        // The buffer size is doubled
+        assert_eq!(1024, bytes.bytes_mut().len());
+    }
+}

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -2,6 +2,8 @@
 
 use bytes::{Bytes, BytesMut, Buf, BufMut};
 
+use std::usize;
+
 const LONG: &'static [u8] = b"mary had a little lamb, little lamb, little lamb";
 const SHORT: &'static [u8] = b"hello world";
 
@@ -841,4 +843,13 @@ fn bytes_buf_mut_advance() {
         // The buffer size is doubled
         assert_eq!(1024, bytes.bytes_mut().len());
     }
+}
+
+#[test]
+#[should_panic]
+fn bytes_reserve_overflow() {
+    let mut bytes = BytesMut::with_capacity(1024);
+    bytes.put_slice(b"hello world");
+
+    bytes.reserve(usize::MAX);
 }

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -1,7 +1,7 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
-use bytes::buf::BufExt;
+use bytes::{Buf, BufMut, Bytes};
+use bytes::buf::{BufExt, BufMutExt};
 use std::io::IoSlice;
 
 #[test]
@@ -15,19 +15,16 @@ fn collect_two_bufs() {
 
 #[test]
 fn writing_chained() {
-    let mut a = BytesMut::with_capacity(64);
-    let mut b = BytesMut::with_capacity(64);
+    let mut a = [0u8; 64];
+    let mut b = [0u8; 64];
 
     {
-        let mut buf = (&mut a).chain(&mut b);
+        let mut buf = (&mut a[..]).chain_mut(&mut b[..]);
 
         for i in 0u8..128 {
             buf.put_u8(i);
         }
     }
-
-    assert_eq!(64, a.len());
-    assert_eq!(64, b.len());
 
     for i in 0..64 {
         let expect = i as u8;


### PR DESCRIPTION
This brings `BytesMut` in line with `Vec<u8>` behavior.

**Note** this PR also fixes an existing bug in `BytesMut::bytes_mut` that exposes invalid slices.

In order to fix a test, `BufMutExt::chain_mut` is provided. Withou this,
it is not possible to chain two `&mut [u8]`.

Closes #170