### PR TITLE
Fix regression in Bytes::truncate

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -373,9 +373,7 @@ impl Bytes {
     /// [`split_off`]: #method.split_off
     #[inline]
     pub fn truncate(&mut self, len: usize) {
-        if len >= self.len {
-            self.len = 0;
-        } else {
+        if len < self.len {
             self.len = len;
         }
     }

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -313,6 +313,18 @@ fn split_off_to_at_gt_len() {
 }
 
 #[test]
+fn truncate() {
+    let s = &b"helloworld"[..];
+    let mut hello = Bytes::from(s);
+    hello.truncate(15);
+    assert_eq!(hello, s);
+    hello.truncate(10);
+    assert_eq!(hello, s);
+    hello.truncate(5);
+    assert_eq!(hello, "hello");
+}
+
+#[test]
 fn freeze_clone_shared() {
     let s = &b"abcdefgh"[..];
     let b = BytesMut::from(s).split().freeze();


### PR DESCRIPTION
Fixing up after https://github.com/tokio-rs/bytes/pull/298#discussion_r351548004

When the length to truncate is greater than the buffer's current length, do nothing instead of clearing the contents.