### PR TITLE
impl `Zeroize` for `BytesMut` (optional)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ std = []
 
 [dependencies]
 serde = { version = "1.0", optional = true }
+zeroize = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]
 loom = "0.2.10"

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1392,6 +1392,16 @@ impl PartialEq<Bytes> for BytesMut {
     }
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::Zeroize for BytesMut {
+    fn zeroize(&mut self) {
+        self.resize(self.capacity(), 0);
+        self.as_mut().zeroize();
+        debug_assert!(self.iter().all(|b| *b == 0));
+        self.clear();
+    }
+}
+
 fn vptr(ptr: *mut u8) -> NonNull<u8> {
     if cfg!(debug_assertions) {
         NonNull::new(ptr).expect("Vec pointer should be non-null")

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -87,3 +87,13 @@ fn test_mut_slice() {
     let mut s = &mut v[..];
     s.put_u32(42);
 }
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut data = BytesMut::from("data");
+    data.zeroize();
+    assert!(data.is_empty());
+}


### PR DESCRIPTION
`zeroize` is a popular Rust crate for securely zeroing memory:

https://crates.io/crates/zeroize

(I am the author)

Presently it's possible to use `Zeroize` with `BytesMut` via `DerefMut` coercion (`Zeroize` is impl'd for `slice::IterMut`).

The implementation in this PR is more complete in that it handles clearing data in the remaining capacity, in the event that it previously contained secrets.

`zeroize` presently has a `bytes-preview` feature (which depends on `bytes` 4.0) which provides this implementation:

https://docs.rs/zeroize/1.0.0/zeroize/#bytes-preview-feature-zeroize-support-for-bytesmut

I'd like to either upstream that implementation, i.e. this PR, and/or drop the `bytes-preview` feature in `zeroize` as otherwise it seems deref coercion is sufficient to get a "good enough" implementation (and anyone who wants something better can make a newtype which does what's in the impl in this commit, in the event this PR doesn't get merged).

tl;dr: this PR provides an optimal implementation of `Zeroize`, but if adding an optional dependency is too onerous, no worries - what we get through deref coercion is "good enough"