### PR TITLE
Add must_use to split, split_off, and split_to

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -288,6 +288,7 @@ impl Bytes {
     /// # Panics
     ///
     /// Panics if `at > len`.
+    #[must_use = "consider Bytes::truncate if you don't need the other half"]
     pub fn split_off(&mut self, at: usize) -> Bytes {
         assert!(at <= self.len());
 
@@ -331,6 +332,7 @@ impl Bytes {
     /// # Panics
     ///
     /// Panics if `at > len`.
+    #[must_use = "consider Bytes::advance if you don't need the other half"]
     pub fn split_to(&mut self, at: usize) -> Bytes {
         assert!(at <= self.len());
 
@@ -912,6 +914,28 @@ unsafe fn release_shared(ptr: *mut Shared) {
     // Drop the data
     Box::from_raw(ptr);
 }
+
+// compile-fails
+
+/// ```compile_fail
+/// use bytes::Bytes;
+/// #[deny(unused_must_use)]
+/// {
+///     let mut b1 = Bytes::from("hello world");
+///     b1.split_to(6);
+/// }
+/// ```
+fn _split_to_must_use() {}
+
+/// ```compile_fail
+/// use bytes::Bytes;
+/// #[deny(unused_must_use)]
+/// {
+///     let mut b1 = Bytes::from("hello world");
+///     b1.split_off(6);
+/// }
+/// ```
+fn _split_off_must_use() {}
 
 // fuzz tests
 #[cfg(all(test, loom))]

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -275,6 +275,7 @@ impl BytesMut {
     /// # Panics
     ///
     /// Panics if `at > capacity`.
+    #[must_use = "consider BytesMut::truncate if you don't need the other half"]
     pub fn split_off(&mut self, at: usize) -> BytesMut {
         assert!(at <= self.capacity());
         unsafe {
@@ -310,6 +311,7 @@ impl BytesMut {
     ///
     /// assert_eq!(other, b"hello world"[..]);
     /// ```
+    #[must_use = "consider BytesMut::advance(len()) if you don't need the other half"]
     pub fn split(&mut self) -> BytesMut {
         let len = self.len();
         self.split_to(len)
@@ -341,6 +343,7 @@ impl BytesMut {
     /// # Panics
     ///
     /// Panics if `at > len`.
+    #[must_use = "consider BytesMut::advance if you don't need the other half"]
     pub fn split_to(&mut self, at: usize) -> BytesMut {
         assert!(at <= self.len());
 
@@ -1427,6 +1430,38 @@ unsafe fn shared_v_drop(data: &mut AtomicPtr<()>, _ptr: *const u8, _len: usize) 
     let shared = (*data.get_mut()) as *mut Shared;
     release_shared(shared as *mut Shared);
 }
+
+// compile-fails
+
+/// ```compile_fail
+/// use bytes::BytesMut;
+/// #[deny(unused_must_use)]
+/// {
+///     let mut b1 = BytesMut::from("hello world");
+///     b1.split_to(6);
+/// }
+/// ```
+fn _split_to_must_use() {}
+
+/// ```compile_fail
+/// use bytes::BytesMut;
+/// #[deny(unused_must_use)]
+/// {
+///     let mut b1 = BytesMut::from("hello world");
+///     b1.split_off(6);
+/// }
+/// ```
+fn _split_off_must_use() {}
+
+/// ```compile_fail
+/// use bytes::BytesMut;
+/// #[deny(unused_must_use)]
+/// {
+///     let mut b1 = BytesMut::from("hello world");
+///     b1.split();
+/// }
+/// ```
+fn _split_must_use() {}
 
 // fuzz tests
 #[cfg(all(test, loom))]

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -176,7 +176,7 @@ fn split_off() {
 #[should_panic]
 fn split_off_oob() {
     let mut hello = Bytes::from(&b"helloworld"[..]);
-    hello.split_off(44);
+    let _ = hello.split_off(44);
 }
 
 #[test]
@@ -273,14 +273,14 @@ fn split_to_2() {
 #[should_panic]
 fn split_to_oob() {
     let mut hello = Bytes::from(&b"helloworld"[..]);
-    hello.split_to(33);
+    let _ = hello.split_to(33);
 }
 
 #[test]
 #[should_panic]
 fn split_to_oob_mut() {
     let mut hello = BytesMut::from(&b"helloworld"[..]);
-    hello.split_to(33);
+    let _ = hello.split_to(33);
 }
 
 #[test]
@@ -300,15 +300,15 @@ fn split_off_to_at_gt_len() {
 
     use std::panic;
 
-    make_bytes().split_to(4);
-    make_bytes().split_off(4);
+    let _ = make_bytes().split_to(4);
+    let _ = make_bytes().split_off(4);
 
     assert!(panic::catch_unwind(move || {
-        make_bytes().split_to(5);
+        let _ = make_bytes().split_to(5);
     }).is_err());
 
     assert!(panic::catch_unwind(move || {
-        make_bytes().split_off(5);
+        let _ = make_bytes().split_off(5);
     }).is_err());
 }
 
@@ -428,7 +428,7 @@ fn reserve_vec_recycling() {
 #[test]
 fn reserve_in_arc_unique_does_not_overallocate() {
     let mut bytes = BytesMut::with_capacity(1000);
-    bytes.split();
+    let _ = bytes.split();
 
     // now bytes is Arc and refcount == 1
 
@@ -440,7 +440,7 @@ fn reserve_in_arc_unique_does_not_overallocate() {
 #[test]
 fn reserve_in_arc_unique_doubles() {
     let mut bytes = BytesMut::with_capacity(1000);
-    bytes.split();
+    let _ = bytes.split();
 
     // now bytes is Arc and refcount == 1
 
@@ -723,12 +723,12 @@ fn bytes_mut_unsplit_arc_different() {
     let mut buf = BytesMut::with_capacity(64);
     buf.extend_from_slice(b"aaaabbbbeeee");
 
-    buf.split_off(8); //arc
+    let _ = buf.split_off(8); //arc
 
     let mut buf2 = BytesMut::with_capacity(64);
     buf2.extend_from_slice(b"ccccddddeeee");
 
-    buf2.split_off(8); //arc
+    let _ = buf2.split_off(8); //arc
 
     buf.unsplit(buf2);
     assert_eq!(b"aaaabbbbccccdddd", &buf[..]);


### PR DESCRIPTION
I've noticed a few places in my own code where I've written `self.bytes.split_off(n);`, and it would be better to use either `truncate` or `advance`. That's because the `split` methods will make a shallow clone, possibly promoting to an Arc.