### PR TITLE
Buf::get_bytes(count)

### DIFF
--- a/src/buf/ext/take.rs
+++ b/src/buf/ext/take.rs
@@ -147,4 +147,15 @@ impl<T: Buf> Buf for Take<T> {
         self.inner.advance(cnt);
         self.limit -= cnt;
     }
+
+    fn to_bytes(&mut self) -> crate::Bytes {
+        self.get_bytes(self.remaining())
+    }
+
+    fn get_bytes(&mut self, cnt: usize) -> crate::Bytes {
+        assert!(cnt <= self.remaining());
+        let ret = self.inner.get_bytes(cnt);
+        self.limit -= cnt;
+        ret
+    }
 }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -529,6 +529,10 @@ impl Buf for Bytes {
     fn to_bytes(&mut self) -> crate::Bytes {
         core::mem::replace(self, Bytes::new())
     }
+
+    fn get_bytes(&mut self, count: usize) -> Bytes {
+        self.split_to(count)
+    }
 }
 
 impl Deref for Bytes {

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -960,6 +960,10 @@ impl Buf for BytesMut {
     fn to_bytes(&mut self) -> crate::Bytes {
         self.split().freeze()
     }
+
+    fn get_bytes(&mut self, cnt: usize) -> crate::Bytes {
+        self.split_to(cnt).freeze()
+    }
 }
 
 impl BufMut for BytesMut {

--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -1,6 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use bytes::Buf;
+use bytes::{Buf, Bytes};
 use std::io::IoSlice;
 
 #[test]
@@ -25,6 +25,20 @@ fn test_fresh_cursor_vec() {
 fn test_get_u8() {
     let mut buf = &b"\x21zomg"[..];
     assert_eq!(0x21, buf.get_u8());
+}
+
+#[test]
+fn get_to_bytes() {
+    let mut buf = &b"abcd"[..];
+    assert_eq!(Bytes::copy_from_slice(b"abcd"), buf.to_bytes());
+    assert_eq!(b"", buf);
+}
+
+#[test]
+fn get_get_bytes() {
+    let mut buf = &b"abcd"[..];
+    assert_eq!(Bytes::copy_from_slice(b"abc"), buf.get_bytes(3));
+    assert_eq!(b"d", buf);
 }
 
 #[test]

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -946,3 +946,37 @@ fn bytes_with_capacity_but_empty() {
     let vec = Vec::with_capacity(1);
     let _ = Bytes::from(vec);
 }
+
+#[test]
+fn bytes_get_bytes() {
+    let mut bytes = Bytes::from(b"abc".to_vec());
+
+    let a = bytes.get_bytes(1);
+    assert_eq!(b"a", a.as_ref());
+    // assert returned bytes object is a subslice of original bytes object
+    assert_eq!(a.as_ref().as_ptr() as usize + 1, bytes.as_ref().as_ptr() as usize);
+
+    let bc = bytes.get_bytes(2);
+    assert_eq!(b"bc", bc.as_ref());
+    // assert returned bytes object is a subslice of original bytes object
+    assert_eq!(bc.as_ref().as_ptr() as usize, a.as_ref().as_ptr() as usize + 1);
+
+    assert_eq!(Bytes::new(), bytes);
+}
+
+#[test]
+fn bytes_mut_get_bytes() {
+    let mut bytes = BytesMut::from(&b"abc"[..]);
+
+    let a = bytes.get_bytes(1);
+    assert_eq!(b"a", a.as_ref());
+    // assert returned bytes object is a subslice of original bytes object
+    assert_eq!(a.as_ref().as_ptr() as usize + 1, bytes.as_ref().as_ptr() as usize);
+
+    let bc = bytes.get_bytes(2);
+    assert_eq!(b"bc", bc.as_ref());
+    // assert returned bytes object is a subslice of original bytes object
+    assert_eq!(bc.as_ref().as_ptr() as usize, a.as_ref().as_ptr() as usize + 1);
+
+    assert_eq!(BytesMut::new(), bytes);
+}

--- a/tests/test_take.rs
+++ b/tests/test_take.rs
@@ -1,6 +1,7 @@
 #![deny(warnings, rust_2018_idioms)]
 
 use bytes::buf::{Buf, BufExt};
+use bytes::Bytes;
 
 #[test]
 fn long_take() {
@@ -9,4 +10,35 @@ fn long_take() {
     let buf = b"hello world".take(100);
     assert_eq!(11, buf.remaining());
     assert_eq!(b"hello world", buf.bytes());
+}
+
+#[test]
+fn take_to_bytes() {
+    let mut abcd = Bytes::copy_from_slice(b"abcd");
+    let abcd_ptr = abcd.as_ptr();
+    let mut take = (&mut abcd).take(2);
+    let ab = take.to_bytes();
+    assert_eq!(Bytes::copy_from_slice(b"ab"), ab);
+    // assert `to_bytes` did not allocate
+    assert_eq!(abcd_ptr, ab.as_ptr());
+    assert_eq!(Bytes::copy_from_slice(b"cd"), abcd);
+}
+
+#[test]
+fn take_get_bytes() {
+    let mut abcd = Bytes::copy_from_slice(b"abcd");
+    let abcd_ptr = abcd.as_ptr();
+    let mut take = (&mut abcd).take(2);
+    let a = take.get_bytes(1);
+    assert_eq!(Bytes::copy_from_slice(b"a"), a);
+    // assert `to_bytes` did not allocate
+    assert_eq!(abcd_ptr, a.as_ptr());
+    assert_eq!(Bytes::copy_from_slice(b"bcd"), abcd);
+}
+
+#[test]
+#[should_panic]
+fn take_get_bytes_panics() {
+    let abcd = Bytes::copy_from_slice(b"abcd");
+    abcd.take(2).get_bytes(3);
 }


### PR DESCRIPTION
This function consumes `count` bytes as `crate::Bytes` object.

Default implementation allocates a new `Bytes` object,
but implementations can reuse allocated memory.

* `Bytes` and `BytesMut` return a view of allocated object
* `Take` and `Chain` try to delegate to underlying `get_bytes` when possible

This diff also optimizes `Buf::to_bytes` for `Chain` (when either
underlying is empty) and for `Take` by delegating to `get_bytes`
function.