### PR TITLE
Optimize Bytes::copy_from_slice

### DIFF
--- a/benches/bytes.rs
+++ b/benches/bytes.rs
@@ -116,3 +116,17 @@ fn split_off_and_drop(b: &mut Bencher) {
         }
     })
 }
+
+#[bench]
+fn copy_from_slice(b: &mut Bencher) {
+    b.iter(|| {
+        Bytes::copy_from_slice(b"abcdef")
+    });
+}
+
+#[bench]
+fn copy_from_slice_and_clone(b: &mut Bencher) {
+    b.iter(|| {
+        Bytes::copy_from_slice(b"abcdef").clone()
+    });
+}


### PR DESCRIPTION
Create a new `SharedInline` `Bytes` representation, which is:

```
struct SharedInline {
    ref_cnt: AtomicUsize,
    cap: usize,
    // data: [u8; cap],
}
```

The advantage of this representation is that we do not need an extra
allocation when cloning `Bytes` which makes such cloning much faster
and without extra allocation.

The drawback is a slightly lower performance of such object destruction
due to atomic decrement.

The bench:

```
#[bench]
fn copy_from_slice_and_clone(b: &mut Bencher) {
    b.iter(|| {
        Bytes::copy_from_slice(b"abcdef").clone()
    });
}
```

becomes two times faster (210ns/iter vs 110ns/iter).

While non-shared bench:

```
#[bench]
fn copy_from_slice(b: &mut Bencher) {
    b.iter(|| {
        Bytes::copy_from_slice(b"abcdef")
    });
}
```

becomes a little slower (85ns/iter vs 90ns/iter).