### PR TITLE
Impl `into_vec` for Bytes

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -843,6 +843,12 @@ impl From<String> for Bytes {
     }
 }
 
+impl From<Bytes> for Vec<u8> {
+    fn from(b: Bytes) -> Self {
+        b.into_vec()
+    }
+}
+
 // ===== impl Vtable =====
 
 impl fmt::Debug for Vtable {


### PR DESCRIPTION
- Carries on from the work in PR #151
- Doesn't fully close issue #86 as `BytesMut::into_vec` is not implemented. Currently you cannot
  convert from a BytesMut to a Vec from a public interface (as like Bytes does) so I left this out for the time being.
- I'm not `100%` on the atomic guarantees here.

**Side note**, I've noticed there is a decent amount of repetition and other tid bits of work that can be done in this lib. Old comments referring to `Inner` etc, no use of `cargo fmt`. I'm happy to jam a decent amount of time into helping refactor, but I would first like to check no other work of this kind is being done offline so I'm not duplicating it. Would the maintainers be interested in PRs of this sort?