### PR TITLE
Make freeze respect the start offset for BytesMuts in Vec mode

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -233,7 +233,9 @@ impl BytesMut {
                 let (off, _) = self.get_vec_pos();
                 let vec = rebuild_vec(self.ptr.as_ptr(), self.len, self.cap, off);
                 mem::forget(self);
-                vec.into()
+                let mut b: Bytes = vec.into();
+                b.advance(off);
+                b
             }
         } else {
             debug_assert_eq!(self.kind(), KIND_ARC);

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -343,6 +343,72 @@ fn freeze_clone_unique() {
 }
 
 #[test]
+fn freeze_after_advance() {
+    let s = &b"abcdefgh"[..];
+    let mut b = BytesMut::from(s);
+    b.advance(1);
+    assert_eq!(b, s[1..]);
+    let b = b.freeze();
+    // Verify fix for #352. Previously, freeze would ignore the start offset
+    // for BytesMuts in Vec mode.
+    assert_eq!(b, s[1..]);
+}
+
+#[test]
+fn freeze_after_advance_arc() {
+    let s = &b"abcdefgh"[..];
+    let mut b = BytesMut::from(s);
+    // Make b Arc
+    let _ = b.split_to(0);
+    b.advance(1);
+    assert_eq!(b, s[1..]);
+    let b = b.freeze();
+    assert_eq!(b, s[1..]);
+}
+
+#[test]
+fn freeze_after_split_to() {
+    let s = &b"abcdefgh"[..];
+    let mut b = BytesMut::from(s);
+    let _ = b.split_to(1);
+    assert_eq!(b, s[1..]);
+    let b = b.freeze();
+    assert_eq!(b, s[1..]);
+}
+
+#[test]
+fn freeze_after_truncate() {
+    let s = &b"abcdefgh"[..];
+    let mut b = BytesMut::from(s);
+    b.truncate(7);
+    assert_eq!(b, s[..7]);
+    let b = b.freeze();
+    assert_eq!(b, s[..7]);
+}
+
+#[test]
+fn freeze_after_truncate_arc() {
+    let s = &b"abcdefgh"[..];
+    let mut b = BytesMut::from(s);
+    // Make b Arc
+    let _ = b.split_to(0);
+    b.truncate(7);
+    assert_eq!(b, s[..7]);
+    let b = b.freeze();
+    assert_eq!(b, s[..7]);
+}
+
+#[test]
+fn freeze_after_split_off() {
+    let s = &b"abcdefgh"[..];
+    let mut b = BytesMut::from(s);
+    let _ = b.split_off(7);
+    assert_eq!(b, s[..7]);
+    let b = b.freeze();
+    assert_eq!(b, s[..7]);
+}
+
+#[test]
 fn fns_defined_for_bytes_mut() {
     let mut bytes = BytesMut::from(&b"hello world"[..]);
 


### PR DESCRIPTION
Fixes #352. This one seemed pretty straightforward to me (advance the `Bytes` before returning). But I'm a Rust newbie, so let me know if I'm missing something.

Also, I guess this is technically a breaking change b/c consuming code might have been depending on the old behavior. E.g. something like
```
let mut b: BytesMut;
b.advance(2);
let b = b.freeze();
// Huh, weird, frozen version doesn't reflect my advance. Guess I'll advance again.
b.advance(2);
```
Y'all's call on how big of a concern that is. My thought is it seems small: The work around above seems less likely than the workaround of using `split_to` as mentioned in the original issue. And the old behavior definitely seemed inconsistent (behavior for Vec mode differed from the behavior for Arc mode, and behavior for `freeze` differed from the behavior for `as_slice`/`as_slice_mut`).