### PR TITLE
Make advance_mut impl of BufMut for Vec<u8> panic if cnt > remaining

### DIFF
--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -990,11 +990,13 @@ impl BufMut for Vec<u8> {
     unsafe fn advance_mut(&mut self, cnt: usize) {
         let len = self.len();
         let remaining = self.capacity() - len;
-        if cnt > remaining {
-            // Reserve additional capacity, and ensure that the total length
-            // will not overflow usize.
-            self.reserve(cnt);
-        }
+
+        assert!(
+            cnt <= remaining,
+            "cannot advance past `remaining_mut`: {:?} <= {:?}",
+            cnt,
+            remaining
+        );
 
         self.set_len(len + cnt);
     }

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -45,13 +45,12 @@ fn test_put_u16() {
 }
 
 #[test]
+#[should_panic(expected = "cannot advance")]
 fn test_vec_advance_mut() {
-    // Regression test for carllerche/bytes#108.
+    // Verify fix for #354
     let mut buf = Vec::with_capacity(8);
     unsafe {
         buf.advance_mut(12);
-        assert_eq!(buf.len(), 12);
-        assert!(buf.capacity() >= 12, "capacity: {}", buf.capacity());
     }
 }
 


### PR DESCRIPTION
Fixes #354.
As suggested [here](https://github.com/tokio-rs/tokio/pull/2030#discussion_r361631519), this PR goes the route of making `advance_mut` for `Vec<u8>` panic if `cnt` > `remaining`. That's definitely a breaking change: Any consumers that expect `some_vec.advance_mut(cnt)` to reserve space will need to reserve it themselves in advance instead.