### PR TITLE
Fix reference in Take docs

### DIFF
--- a/src/buf/ext/take.rs
+++ b/src/buf/ext/take.rs
@@ -5,7 +5,7 @@ use core::cmp;
 /// A `Buf` adapter which limits the bytes read from an underlying buffer.
 ///
 /// This struct is generally created by calling `take()` on `Buf`. See
-/// documentation of [`take()`](trait.Buf.html#method.take) for more details.
+/// documentation of [`take()`](trait.BufExt.html#method.take) for more details.
 #[derive(Debug)]
 pub struct Take<T> {
     inner: T,


### PR DESCRIPTION
On page https://docs.rs/bytes/0.5.4/bytes/buf/ext/struct.Take.html
`take()` lead to https://docs.rs/bytes/0.5.4/bytes/buf/ext/trait.Buf.html#method.take
> The requested resource does not exist 

Should be: https://docs.rs/bytes/0.5.4/bytes/buf/ext/trait.BufExt.html#method.take