### PR TITLE
Fix tests for no_std build

### DIFF
--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -1,6 +1,7 @@
 #![deny(warnings, rust_2018_idioms)]
 
 use bytes::Buf;
+#[cfg(feature = "std")]
 use std::io::IoSlice;
 
 #[test]
@@ -42,6 +43,7 @@ fn test_get_u16_buffer_underflow() {
     buf.get_u16();
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_bufs_vec() {
     let buf = &b"hello world"[..];

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -1,8 +1,10 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use bytes::{buf::IoSliceMut, BufMut, BytesMut};
-use std::usize;
-use std::fmt::Write;
+use bytes::{BufMut, BytesMut};
+#[cfg(feature = "std")]
+use bytes::buf::IoSliceMut;
+use core::usize;
+use core::fmt::Write;
 
 #[test]
 fn test_vec_as_mut_buf() {
@@ -64,6 +66,7 @@ fn test_clone() {
     assert!(buf != buf2);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_bufs_vec_mut() {
     let b1: &mut [u8] = &mut [];

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -2,6 +2,7 @@
 
 use bytes::{Buf, BufMut, Bytes};
 use bytes::buf::{BufExt, BufMutExt};
+#[cfg(feature = "std")]
 use std::io::IoSlice;
 
 #[test]
@@ -42,6 +43,7 @@ fn iterating_two_bufs() {
     assert_eq!(res, &b"helloworld"[..]);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn vectored_read() {
     let a = Bytes::from(&b"hello"[..]);

--- a/tests/test_reader.rs
+++ b/tests/test_reader.rs
@@ -1,4 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
+#![cfg(feature = "std")]
 
 use std::io::{BufRead, Read};
 


### PR DESCRIPTION
This fixes `cargo test --no-default-features`.