### PR TITLE
Allow using serde feature in no_std environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 serde_test = "1.0"


### PR DESCRIPTION
When `serde` is used, it would enable its default feature `std`.
This of course breaks no_std build.

Fix this by disabling serde's default features. This should work for
both serde + std and serde + no_std cases.