### PR TITLE
Fix CI failure on MacOS

### DIFF
--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -13,7 +13,7 @@ jobs:
 
       ${{ if parameters.cross }}:
         MacOS:
-          vmImage: macOS-10.13
+          vmImage: macOS-10.14
         Windows:
           vmImage: vs2017-win2016
   pool:


### PR DESCRIPTION
macOS-10.13 has been removed.

Ref: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml