### PR TITLE
Deny warnings for doc tests

### DIFF
--- a/src/buf/ext/mod.rs
+++ b/src/buf/ext/mod.rs
@@ -27,7 +27,7 @@ pub trait BufExt: Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Buf, BufMut, buf::BufExt};
+    /// use bytes::{BufMut, buf::BufExt};
     ///
     /// let mut buf = b"hello world"[..].take(5);
     /// let mut dst = vec![];
@@ -79,7 +79,7 @@ pub trait BufExt: Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Buf, Bytes, buf::BufExt};
+    /// use bytes::{Bytes, buf::BufExt};
     /// use std::io::Read;
     ///
     /// let buf = Bytes::from("hello world");
@@ -135,7 +135,7 @@ pub trait BufMutExt: BufMut {
     /// # Examples
     ///
     /// ```
-    /// use bytes::{BufMut, buf::BufMutExt};
+    /// use bytes::buf::BufMutExt;
     /// use std::io::Write;
     ///
     /// let mut buf = vec![].writer();

--- a/src/buf/ext/reader.rs
+++ b/src/buf/ext/reader.rs
@@ -26,7 +26,7 @@ impl<B: Buf> Reader<B> {
     /// ```rust
     /// use bytes::buf::BufExt;
     ///
-    /// let mut buf = b"hello world".reader();
+    /// let buf = b"hello world".reader();
     ///
     /// assert_eq!(b"hello world", buf.get_ref());
     /// ```

--- a/src/buf/ext/take.rs
+++ b/src/buf/ext/take.rs
@@ -22,7 +22,7 @@ impl<T> Take<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use bytes::buf::{Buf, BufMut, BufExt};
+    /// use bytes::buf::{BufMut, BufExt};
     ///
     /// let mut buf = b"hello world".take(2);
     /// let mut dst = vec![];
@@ -49,7 +49,7 @@ impl<T> Take<T> {
     /// ```rust
     /// use bytes::{Buf, buf::BufExt};
     ///
-    /// let mut buf = b"hello world".take(2);
+    /// let buf = b"hello world".take(2);
     ///
     /// assert_eq!(11, buf.get_ref().remaining());
     /// ```
@@ -110,7 +110,7 @@ impl<T> Take<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use bytes::{Buf, BufMut, buf::BufExt};
+    /// use bytes::{BufMut, buf::BufExt};
     ///
     /// let mut buf = b"hello world".take(2);
     /// let mut dst = vec![];

--- a/src/buf/ext/writer.rs
+++ b/src/buf/ext/writer.rs
@@ -26,7 +26,7 @@ impl<B: BufMut> Writer<B> {
     /// ```rust
     /// use bytes::buf::BufMutExt;
     ///
-    /// let mut buf = Vec::with_capacity(1024).writer();
+    /// let buf = Vec::with_capacity(1024).writer();
     ///
     /// assert_eq!(1024, buf.get_ref().capacity());
     /// ```

--- a/src/buf/iter.rs
+++ b/src/buf/iter.rs
@@ -9,7 +9,7 @@ use crate::Buf;
 /// Basic usage:
 ///
 /// ```
-/// use bytes::{Buf, Bytes};
+/// use bytes::Bytes;
 ///
 /// let buf = Bytes::from(&b"abc"[..]);
 /// let mut iter = buf.into_iter();
@@ -33,7 +33,7 @@ impl<T> IntoIter<T> {
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Buf, Bytes};
+    /// use bytes::Bytes;
     /// use bytes::buf::IntoIter;
     ///
     /// let buf = Bytes::from_static(b"abc");
@@ -47,6 +47,7 @@ impl<T> IntoIter<T> {
     pub fn new(inner: T) -> IntoIter<T> {
         IntoIter { inner }
     }
+
     /// Consumes this `IntoIter`, returning the underlying value.
     ///
     /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@
     missing_debug_implementations,
     rust_2018_idioms
 )]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 #![doc(html_root_url = "https://docs.rs/bytes/0.5.4")]
 #![no_std]
 


### PR DESCRIPTION
There are some unused imports/`mut`s.

Refs: https://github.com/tokio-rs/tokio/pull/1539