### PR TITLE
tiny optimization on reclaim inner buffer

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -618,9 +618,11 @@ impl BytesMut {
                     // The capacity is sufficient, reclaim the buffer
                     let ptr = v.as_mut_ptr();
 
-                    ptr::copy(self.ptr.as_ptr(), ptr, len);
+                    if self.ptr.as_ptr() != ptr {
+                        ptr::copy(self.ptr.as_ptr(), ptr, len);
+                        self.ptr = vptr(ptr);
+                    }
 
-                    self.ptr = vptr(ptr);
                     self.cap = v.capacity();
 
                     return;


### PR DESCRIPTION
`BytesMut::reserve` may do unnecessary copying on inner buffer.

``` rust
let mut buf = BytesMut::with_capacity(64);

buf.put_slice(b"12345");
let t = buf.split_off(buf.len());

// do not put anything into t

assert_eq!(buf.capacity(), 5);
assert_eq!(t.capacity(), 64 - 5);

buf.unsplit(t);
assert_eq!(buf.capacity(), 5); // surprise?

buf.reserve(1); // copy "12345" in same buf.
assert_eq!(buf.capacity(), 64);
```