### PR TITLE
Change default lint level to warning and deny warnings in CI

### DIFF
--- a/benches/buf.rs
+++ b/benches/buf.rs
@@ -1,5 +1,5 @@
 #![feature(test)]
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 extern crate test;
 

--- a/benches/bytes.rs
+++ b/benches/bytes.rs
@@ -1,5 +1,5 @@
 #![feature(test)]
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 extern crate test;
 

--- a/benches/bytes_mut.rs
+++ b/benches/bytes_mut.rs
@@ -1,5 +1,5 @@
 #![feature(test)]
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 extern crate test;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms
-)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))

--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use bytes::Buf;
 #[cfg(feature = "std")]

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 #[cfg(feature = "std")]
 use bytes::buf::IoSliceMut;

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use bytes::buf::{BufExt, BufMutExt};
 use bytes::{Buf, BufMut, Bytes};

--- a/tests/test_debug.rs
+++ b/tests/test_debug.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use bytes::Bytes;
 

--- a/tests/test_iter.rs
+++ b/tests/test_iter.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use bytes::Bytes;
 

--- a/tests/test_reader.rs
+++ b/tests/test_reader.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 #![cfg(feature = "std")]
 
 use std::io::{BufRead, Read};

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "serde")]
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use serde_test::{assert_tokens, Token};
 

--- a/tests/test_take.rs
+++ b/tests/test_take.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use bytes::buf::{Buf, BufExt};
 


### PR DESCRIPTION
If the API we are currently using becomes deprecated, deprecated warnings may prevent previously released versions from compiling. It can work around by [--cap-lints](https://doc.rust-lang.org/rustc/lints/levels.html#capping-lints), but it is not very good.

As we already applied -Dwarnings in CI, this PR only changes denied lints in code:

https://github.com/tokio-rs/bytes/blob/a3304e8b8b74e2d5260d8419b6d8075e004e4c39/.github/workflows/ci.yml#L11-L13

Also, seem to there is no way to pass -Dwarnings to the doc tests at the time, so this PR doesn't change the lint level of the doc tests. However, as [`#[doc(test(attr(deny(..)))]`](https://doc.rust-lang.org/rustdoc/the-doc-attribute.html#testattr) is enabled only when doc test is run, the above issue does not occur. See also https://github.com/rust-lang/futures-rs/pull/1672#issuecomment-502018036 for this.

Related: https://github.com/tokio-rs/tokio/issues/1083#issuecomment-491411976, https://github.com/rust-lang/futures-rs/pull/1448#issuecomment-460572701