### PR TITLE
Add From Vec<u8> for BytesMut

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1048,6 +1048,12 @@ impl<'a> From<&'a [u8]> for BytesMut {
     }
 }
 
+impl From<Vec<u8>> for BytesMut {
+    fn from(src: Vec<u8>) -> BytesMut {
+        BytesMut::from_vec(src)
+    }
+}
+
 impl<'a> From<&'a str> for BytesMut {
     fn from(src: &'a str) -> BytesMut {
         BytesMut::from(src.as_bytes())


### PR DESCRIPTION
This impl exists for `Bytes` but not `BytesMut`, you have to use a `&[u8]` which calls `to_vec` again when it could just use the original vec.