### PR TITLE
Fix CI failure on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
-        run: rustup update stable && rustup default stable
+        # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
+        run: rustup update stable --no-self-update && rustup default stable
       - name: Test
         run: . ci/test-stable.sh test
 


### PR DESCRIPTION
--no-self-update is necessary because the windows environment cannot self-update rustup.exe.

I knew about this issue, but I forgot to do this in #392 because recently github actions had the latest rustup.
