### PR TITLE
Add inline attribute to BytesMut::split

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -325,6 +325,7 @@ impl BytesMut {
     ///
     /// assert_eq!(other, b"hello world"[..]);
     /// ```
+    #[inline]
     #[must_use = "consider BytesMut::advance(len()) if you don't need the other half"]
     pub fn split(&mut self) -> BytesMut {
         let len = self.len();


### PR DESCRIPTION
It's just a line since `.len()` is inline