### PR TITLE
Remove BufMut::bytes_vectored_mut()

### DIFF
--- a/src/buf/ext/chain.rs
+++ b/src/buf/ext/chain.rs
@@ -4,8 +4,6 @@ use crate::{Buf, BufMut};
 use core::mem::MaybeUninit;
 
 #[cfg(feature = "std")]
-use crate::buf::IoSliceMut;
-#[cfg(feature = "std")]
 use std::io::IoSlice;
 
 /// A `Chain` sequences two buffers.
@@ -209,13 +207,6 @@ where
         }
 
         self.b.advance_mut(cnt);
-    }
-
-    #[cfg(feature = "std")]
-    fn bytes_vectored_mut<'a>(&'a mut self, dst: &mut [IoSliceMut<'a>]) -> usize {
-        let mut n = self.a.bytes_vectored_mut(dst);
-        n += self.b.bytes_vectored_mut(&mut dst[n..]);
-        n
     }
 }
 

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -24,7 +24,5 @@ mod vec_deque;
 
 pub use self::buf_impl::Buf;
 pub use self::buf_mut::BufMut;
-#[cfg(feature = "std")]
-pub use self::buf_mut::IoSliceMut;
 pub use self::ext::{BufExt, BufMutExt};
 pub use self::iter::IntoIter;

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -1,7 +1,5 @@
 #![warn(rust_2018_idioms)]
 
-#[cfg(feature = "std")]
-use bytes::buf::IoSliceMut;
 use bytes::{BufMut, BytesMut};
 use core::fmt::Write;
 use core::usize;
@@ -64,23 +62,6 @@ fn test_clone() {
 
     buf.write_str(" of our emergency broadcast system").unwrap();
     assert!(buf != buf2);
-}
-
-#[cfg(feature = "std")]
-#[test]
-fn test_bufs_vec_mut() {
-    let b1: &mut [u8] = &mut [];
-    let b2: &mut [u8] = &mut [];
-    let mut dst = [IoSliceMut::from(b1), IoSliceMut::from(b2)];
-
-    // with no capacity
-    let mut buf = BytesMut::new();
-    assert_eq!(buf.capacity(), 0);
-    assert_eq!(1, buf.bytes_vectored_mut(&mut dst[..]));
-
-    // with capacity
-    let mut buf = BytesMut::with_capacity(64);
-    assert_eq!(1, buf.bytes_vectored_mut(&mut dst[..]));
 }
 
 #[test]


### PR DESCRIPTION
There are issues with regards to uninitialized memory. We are avoiding
stabilizing this function for now.