### PR TITLE
Make BufMut an unsafe trait

### DIFF
--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -30,7 +30,7 @@ use alloc::{boxed::Box, vec::Vec};
 ///
 /// assert_eq!(buf, b"hello world");
 /// ```
-pub trait BufMut {
+pub unsafe trait BufMut {
     /// Returns the number of bytes that can be written from the current
     /// position until the end of the buffer is reached.
     ///
@@ -992,15 +992,15 @@ macro_rules! deref_forward_bufmut {
     };
 }
 
-impl<T: BufMut + ?Sized> BufMut for &mut T {
+unsafe impl<T: BufMut + ?Sized> BufMut for &mut T {
     deref_forward_bufmut!();
 }
 
-impl<T: BufMut + ?Sized> BufMut for Box<T> {
+unsafe impl<T: BufMut + ?Sized> BufMut for Box<T> {
     deref_forward_bufmut!();
 }
 
-impl BufMut for &mut [u8] {
+unsafe impl BufMut for &mut [u8] {
     #[inline]
     fn remaining_mut(&self) -> usize {
         self.len()
@@ -1020,7 +1020,7 @@ impl BufMut for &mut [u8] {
     }
 }
 
-impl BufMut for Vec<u8> {
+unsafe impl BufMut for Vec<u8> {
     #[inline]
     fn remaining_mut(&self) -> usize {
         usize::MAX - self.len()

--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -174,7 +174,7 @@ where
     }
 }
 
-impl<T, U> BufMut for Chain<T, U>
+unsafe impl<T, U> BufMut for Chain<T, U>
 where
     T: BufMut,
     U: BufMut,

--- a/src/buf/limit.rs
+++ b/src/buf/limit.rs
@@ -55,7 +55,7 @@ impl<T> Limit<T> {
     }
 }
 
-impl<T: BufMut> BufMut for Limit<T> {
+unsafe impl<T: BufMut> BufMut for Limit<T> {
     fn remaining_mut(&self) -> usize {
         cmp::min(self.inner.remaining_mut(), self.limit)
     }

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -966,7 +966,7 @@ impl Buf for BytesMut {
     }
 }
 
-impl BufMut for BytesMut {
+unsafe impl BufMut for BytesMut {
     #[inline]
     fn remaining_mut(&self) -> usize {
         usize::MAX - self.len()

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -75,7 +75,7 @@ fn test_mut_slice() {
 fn test_deref_bufmut_forwards() {
     struct Special;
 
-    impl BufMut for Special {
+    unsafe impl BufMut for Special {
         fn remaining_mut(&self) -> usize {
             unreachable!("remaining_mut");
         }


### PR DESCRIPTION
Users of `BufMut` are unable to defend against incorrect implementations
of `BufMut`, this makes the trait unsafe to implement.

Fixes #329

cc @kixunil