### PR TITLE
Switch `BufMut::bytes_mut` from `MaybeUninit` to `&mut UninitSlice`, a type ownec by `bytes` for this purpose

### DIFF
--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -69,19 +69,14 @@ pub unsafe trait BufMut {
     ///
     /// let mut buf = Vec::with_capacity(16);
     ///
-    /// unsafe {
-    ///     // MaybeUninit::as_mut_ptr
-    ///     buf.bytes_mut()[0..].as_mut_ptr().write(b'h');
-    ///     buf.bytes_mut()[1..].as_mut_ptr().write(b'e');
+    /// // Write some data
+    /// buf.bytes_mut()[0..2].write_slice(b"he");
+    /// unsafe { buf.advance_mut(2) };
     ///
-    ///     buf.advance_mut(2);
+    /// // write more bytes
+    /// buf.bytes_mut()[0..3].write_slice(b"llo");
     ///
-    ///     buf.bytes_mut()[0..].as_mut_ptr().write(b'l');
-    ///     buf.bytes_mut()[1..].as_mut_ptr().write(b'l');
-    ///     buf.bytes_mut()[2..].as_mut_ptr().write(b'o');
-    ///
-    ///     buf.advance_mut(3);
-    /// }
+    /// unsafe { buf.advance_mut(3); }
     ///
     /// assert_eq!(5, buf.len());
     /// assert_eq!(buf, b"hello");

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -70,11 +70,11 @@ pub unsafe trait BufMut {
     /// let mut buf = Vec::with_capacity(16);
     ///
     /// // Write some data
-    /// buf.bytes_mut()[0..2].write_slice(b"he");
+    /// buf.bytes_mut()[0..2].copy_from_slice(b"he");
     /// unsafe { buf.advance_mut(2) };
     ///
     /// // write more bytes
-    /// buf.bytes_mut()[0..3].write_slice(b"llo");
+    /// buf.bytes_mut()[0..3].copy_from_slice(b"llo");
     ///
     /// unsafe { buf.advance_mut(3); }
     ///

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -71,14 +71,14 @@ pub unsafe trait BufMut {
     ///
     /// unsafe {
     ///     // MaybeUninit::as_mut_ptr
-    ///     buf.bytes_mut()[0].as_mut_ptr().write(b'h');
-    ///     buf.bytes_mut()[1].as_mut_ptr().write(b'e');
+    ///     buf.bytes_mut()[0..].as_mut_ptr().write(b'h');
+    ///     buf.bytes_mut()[1..].as_mut_ptr().write(b'e');
     ///
     ///     buf.advance_mut(2);
     ///
-    ///     buf.bytes_mut()[0].as_mut_ptr().write(b'l');
-    ///     buf.bytes_mut()[1].as_mut_ptr().write(b'l');
-    ///     buf.bytes_mut()[2].as_mut_ptr().write(b'o');
+    ///     buf.bytes_mut()[0..].as_mut_ptr().write(b'l');
+    ///     buf.bytes_mut()[1..].as_mut_ptr().write(b'l');
+    ///     buf.bytes_mut()[2..].as_mut_ptr().write(b'o');
     ///
     ///     buf.advance_mut(3);
     /// }
@@ -140,14 +140,14 @@ pub unsafe trait BufMut {
     ///
     /// unsafe {
     ///     // MaybeUninit::as_mut_ptr
-    ///     buf.bytes_mut()[0].as_mut_ptr().write(b'h');
-    ///     buf.bytes_mut()[1].as_mut_ptr().write(b'e');
+    ///     buf.bytes_mut()[0..].as_mut_ptr().write(b'h');
+    ///     buf.bytes_mut()[1..].as_mut_ptr().write(b'e');
     ///
     ///     buf.advance_mut(2);
     ///
-    ///     buf.bytes_mut()[0].as_mut_ptr().write(b'l');
-    ///     buf.bytes_mut()[1].as_mut_ptr().write(b'l');
-    ///     buf.bytes_mut()[2].as_mut_ptr().write(b'o');
+    ///     buf.bytes_mut()[0..].as_mut_ptr().write(b'l');
+    ///     buf.bytes_mut()[1..].as_mut_ptr().write(b'l');
+    ///     buf.bytes_mut()[2..].as_mut_ptr().write(b'o');
     ///
     ///     buf.advance_mut(3);
     /// }

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -2,11 +2,7 @@ use crate::buf::{limit, Chain, Limit, UninitSlice};
 #[cfg(feature = "std")]
 use crate::buf::{writer, Writer};
 
-use core::{
-    cmp,
-    mem,
-    ptr, usize,
-};
+use core::{cmp, mem, ptr, usize};
 
 use alloc::{boxed::Box, vec::Vec};
 
@@ -1051,9 +1047,7 @@ unsafe impl BufMut for Vec<u8> {
         let len = self.len();
 
         let ptr = self.as_mut_ptr();
-        unsafe {
-            &mut UninitSlice::from_raw_parts_mut(ptr, cap)[len..]
-        }
+        unsafe { &mut UninitSlice::from_raw_parts_mut(ptr, cap)[len..] }
     }
 
     // Specialize these methods so they can skip checking `remaining_mut`

--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -1,7 +1,5 @@
-use crate::buf::IntoIter;
+use crate::buf::{IntoIter, UninitSlice};
 use crate::{Buf, BufMut};
-
-use core::mem::MaybeUninit;
 
 #[cfg(feature = "std")]
 use std::io::IoSlice;
@@ -183,7 +181,7 @@ where
         self.a.remaining_mut() + self.b.remaining_mut()
     }
 
-    fn bytes_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+    fn bytes_mut(&mut self) -> &mut UninitSlice {
         if self.a.has_remaining_mut() {
             self.a.bytes_mut()
         } else {

--- a/src/buf/limit.rs
+++ b/src/buf/limit.rs
@@ -1,3 +1,4 @@
+use crate::buf::UninitSlice;
 use crate::BufMut;
 
 use core::{cmp, mem::MaybeUninit};
@@ -60,7 +61,7 @@ unsafe impl<T: BufMut> BufMut for Limit<T> {
         cmp::min(self.inner.remaining_mut(), self.limit)
     }
 
-    fn bytes_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+    fn bytes_mut(&mut self) -> &mut UninitSlice {
         let bytes = self.inner.bytes_mut();
         let end = cmp::min(bytes.len(), self.limit);
         &mut bytes[..end]

--- a/src/buf/limit.rs
+++ b/src/buf/limit.rs
@@ -1,7 +1,7 @@
 use crate::buf::UninitSlice;
 use crate::BufMut;
 
-use core::{cmp, mem::MaybeUninit};
+use core::cmp;
 
 /// A `BufMut` adapter which limits the amount of bytes that can be written
 /// to an underlying buffer.

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -29,7 +29,7 @@ mod vec_deque;
 mod writer;
 
 pub use self::buf_impl::Buf;
-pub use self::buf_mut::BufMut;
+pub use self::buf_mut::{BufMut, UninitSlice};
 pub use self::chain::Chain;
 pub use self::iter::IntoIter;
 pub use self::limit::Limit;

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -24,16 +24,18 @@ mod limit;
 #[cfg(feature = "std")]
 mod reader;
 mod take;
+mod uninit_slice;
 mod vec_deque;
 #[cfg(feature = "std")]
 mod writer;
 
 pub use self::buf_impl::Buf;
-pub use self::buf_mut::{BufMut, UninitSlice};
+pub use self::buf_mut::BufMut;
 pub use self::chain::Chain;
 pub use self::iter::IntoIter;
 pub use self::limit::Limit;
 pub use self::take::Take;
+pub use self::uninit_slice::UninitSlice;
 
 #[cfg(feature = "std")]
 pub use self::{reader::Reader, writer::Writer};

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::mem::MaybeUninit;
 use core::ops::{
     Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
@@ -8,7 +9,6 @@ use core::ops::{
 /// Returned by `BufMut::bytes_mut()`, the referenced byte slice may be
 /// uninitialized. The wrapper provides safe access without introducing
 /// undefined behavior.
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct UninitSlice([MaybeUninit<u8>]);
 
@@ -82,6 +82,13 @@ impl UninitSlice {
     /// ```
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+}
+
+impl fmt::Debug for UninitSlice {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("UninitSlice[...]")
+            .finish()
     }
 }
 

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -4,11 +4,20 @@ use core::ops::{
     Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
 };
 
-/// Uninititialized byte slice.
+/// Uninitialized byte slice.
 ///
 /// Returned by `BufMut::bytes_mut()`, the referenced byte slice may be
 /// uninitialized. The wrapper provides safe access without introducing
 /// undefined behavior.
+///
+/// The safety invariants of this wrapper are:
+///
+///  1. Reading from an `UninitSlice` is undefined behavior.
+///  2. Writing uninitialized bytes to an `UninitSlice` is undefined behavior.
+///
+/// The difference between `&mut UninitSlice` and `&mut [MaybeUninit<u8>]` is
+/// that it is possible in safe code to write uninitialized bytes to an
+/// `&mut [MaybeUninit<u8>]`, which this type prohibits.
 #[repr(transparent)]
 pub struct UninitSlice([MaybeUninit<u8>]);
 

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -1,0 +1,60 @@
+use core::mem::MaybeUninit;
+use core::ops::{Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+
+/// TODO
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct UninitSlice([MaybeUninit<u8>]);
+
+impl UninitSlice {
+    /// TODO
+    pub unsafe fn from_raw_parts_mut<'a>(ptr: *mut u8, len: usize) -> &'a mut UninitSlice {
+        let maybe_init: &mut [MaybeUninit<u8>] = std::slice::from_raw_parts_mut(ptr as *mut _, len);
+        &mut *(maybe_init as *mut [MaybeUninit<u8>] as *mut UninitSlice)
+    }
+
+    /// TODO
+    pub fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr() as *const _
+    }
+
+    /// TODO
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.0.as_mut_ptr() as *mut _
+    }
+
+    /// TODO
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+macro_rules! impl_index {
+    ($($t:ty),*) => {
+        $(
+            impl Index<$t> for UninitSlice {
+                type Output = UninitSlice;
+            
+                fn index(&self, index: $t) -> &UninitSlice {
+                    let maybe_uninit = &self.0[index];
+                    unsafe { &*(maybe_uninit as *const [MaybeUninit<u8>] as *const UninitSlice) }
+                }
+            }
+            
+            impl IndexMut<$t> for UninitSlice {
+                fn index_mut(&mut self, index: $t) -> &mut UninitSlice {
+                    let maybe_uninit = &mut self.0[index];
+                    unsafe { &mut *(maybe_uninit as *mut [MaybeUninit<u8>] as *mut UninitSlice) }
+                }
+            }
+        )*
+    };
+}
+
+impl_index!(
+    Range<usize>,
+    RangeFrom<usize>,
+    RangeFull,
+    RangeInclusive<usize>,
+    RangeTo<usize>,
+    RangeToInclusive<usize>);

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -67,14 +67,16 @@ impl UninitSlice {
     pub fn write_byte(&mut self, index: usize, byte: u8) {
         assert!(index < self.len());
 
-        unsafe { self.as_mut_ptr().offset(index as isize).write(byte) };
+        unsafe { self[index..].as_mut_ptr().write(byte) }
     }
 
-    /// Writes the contents of `src` into `self`.
+    /// Copies bytes  from `src` into `self`.
+    ///
+    /// The length of `src` must be the same as `self`.
     ///
     /// # Panics
     ///
-    /// The function panics if `self` has a different length than `src`.
+    /// The function panics if `src` has a different length than `self`.
     ///
     /// # Examples
     ///
@@ -84,11 +86,11 @@ impl UninitSlice {
     /// let mut data = [b'f', b'o', b'o'];
     /// let slice = unsafe { UninitSlice::from_raw_parts_mut(data.as_mut_ptr(), 3) };
     ///
-    /// slice.write_slice(b"bar");
+    /// slice.copy_from_slice(b"bar");
     ///
     /// assert_eq!(b"bar", &data[..]);
     /// ```
-    pub fn write_slice(&mut self, src: &[u8]) {
+    pub fn copy_from_slice(&mut self, src: &[u8]) {
         use core::ptr;
 
         assert_eq!(self.len(), src.len());
@@ -103,7 +105,7 @@ impl UninitSlice {
     /// # Safety
     ///
     /// The caller **must not** read from the referenced memory and **must not**
-    /// write uninitialized bytes to the slice either.
+    /// write **uninitialized** bytes to the slice either.
     ///
     /// # Examples
     ///

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -80,7 +80,7 @@ impl UninitSlice {
     /// assert_eq!(b"bar", &data[..]);
     /// ```
     pub fn write_slice(&mut self, src: &[u8]) {
-        use std::ptr;
+        use core::ptr;
 
         assert_eq!(self.len(), src.len());
 

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -87,8 +87,7 @@ impl UninitSlice {
 
 impl fmt::Debug for UninitSlice {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("UninitSlice[...]")
-            .finish()
+        fmt.debug_struct("UninitSlice[...]").finish()
     }
 }
 

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -149,14 +149,14 @@ macro_rules! impl_index {
                 type Output = UninitSlice;
 
                 fn index(&self, index: $t) -> &UninitSlice {
-                    let maybe_uninit = &self.0[index];
+                    let maybe_uninit: &[MaybeUninit<u8>] = &self.0[index];
                     unsafe { &*(maybe_uninit as *const [MaybeUninit<u8>] as *const UninitSlice) }
                 }
             }
 
             impl IndexMut<$t> for UninitSlice {
                 fn index_mut(&mut self, index: $t) -> &mut UninitSlice {
-                    let maybe_uninit = &mut self.0[index];
+                    let maybe_uninit: &mut [MaybeUninit<u8>] = &mut self.0[index];
                     unsafe { &mut *(maybe_uninit as *mut [MaybeUninit<u8>] as *mut UninitSlice) }
                 }
             }

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -3,29 +3,83 @@ use core::ops::{
     Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
 };
 
-/// TODO
+/// Uninititialized byte slice.
+///
+/// Returned by `BufMut::bytes_mut()`, the referenced byte slice may be
+/// uninitialized. The wrapper provides safe access without introducing
+/// undefined behavior.
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct UninitSlice([MaybeUninit<u8>]);
 
 impl UninitSlice {
-    /// TODO
+    /// Create a `&mut UninitSlice` from a pointer and a length.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `ptr` references a valid memory region owned
+    /// by the caller representing a byte slice for the duration of `'a`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::buf::UninitSlice;
+    ///
+    /// let bytes = b"hello world".to_vec();
+    /// let ptr = bytes.as_ptr() as *mut _;
+    /// let len = bytes.len();
+    ///
+    /// let slice = unsafe { UninitSlice::from_raw_parts_mut(ptr, len) };
+    /// ```
     pub unsafe fn from_raw_parts_mut<'a>(ptr: *mut u8, len: usize) -> &'a mut UninitSlice {
-        let maybe_init: &mut [MaybeUninit<u8>] = std::slice::from_raw_parts_mut(ptr as *mut _, len);
+        let maybe_init: &mut [MaybeUninit<u8>] =
+            core::slice::from_raw_parts_mut(ptr as *mut _, len);
         &mut *(maybe_init as *mut [MaybeUninit<u8>] as *mut UninitSlice)
     }
 
-    /// TODO
+    /// Return a raw pointer to the slice's buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut data = [0, 1, 2];
+    /// let mut slice = &mut data[..];
+    /// let ptr = BufMut::bytes_mut(&mut slice).as_ptr();
+    /// ```
     pub fn as_ptr(&self) -> *const u8 {
         self.0.as_ptr() as *const _
     }
 
-    /// TODO
+    /// Return a raw pointer to the slice's buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut data = [0, 1, 2];
+    /// let mut slice = &mut data[..];
+    /// let ptr = BufMut::bytes_mut(&mut slice).as_mut_ptr();
+    /// ```
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.0.as_mut_ptr() as *mut _
     }
 
-    /// TODO
+    /// Returns the number of bytes in the slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut data = [0, 1, 2];
+    /// let mut slice = &mut data[..];
+    /// let len = BufMut::bytes_mut(&mut slice).len();
+    ///
+    /// assert_eq!(len, 3);
+    /// ```
     pub fn len(&self) -> usize {
         self.0.len()
     }

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -70,7 +70,7 @@ impl UninitSlice {
         unsafe { self.as_mut_ptr().offset(index as isize).write(byte) };
     }
 
-    /// Writes the contents of `src` into `self.
+    /// Writes the contents of `src` into `self`.
     ///
     /// # Panics
     ///

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -1,5 +1,7 @@
 use core::mem::MaybeUninit;
-use core::ops::{Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+use core::ops::{
+    Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
+};
 
 /// TODO
 #[derive(Debug)]
@@ -34,13 +36,13 @@ macro_rules! impl_index {
         $(
             impl Index<$t> for UninitSlice {
                 type Output = UninitSlice;
-            
+
                 fn index(&self, index: $t) -> &UninitSlice {
                     let maybe_uninit = &self.0[index];
                     unsafe { &*(maybe_uninit as *const [MaybeUninit<u8>] as *const UninitSlice) }
                 }
             }
-            
+
             impl IndexMut<$t> for UninitSlice {
                 fn index_mut(&mut self, index: $t) -> &mut UninitSlice {
                     let maybe_uninit = &mut self.0[index];
@@ -57,4 +59,5 @@ impl_index!(
     RangeFull,
     RangeInclusive<usize>,
     RangeTo<usize>,
-    RangeToInclusive<usize>);
+    RangeToInclusive<usize>
+);

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 
 use bytes::{BufMut, BytesMut};
+use bytes::buf::UninitSlice;
 use core::fmt::Write;
 use core::usize;
 
@@ -80,7 +81,7 @@ fn test_deref_bufmut_forwards() {
             unreachable!("remaining_mut");
         }
 
-        fn bytes_mut(&mut self) -> &mut [std::mem::MaybeUninit<u8>] {
+        fn bytes_mut(&mut self) -> &mut UninitSlice {
             unreachable!("bytes_mut");
         }
 

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 
-use bytes::{BufMut, BytesMut};
 use bytes::buf::UninitSlice;
+use bytes::{BufMut, BytesMut};
 use core::fmt::Write;
 use core::usize;
 

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -100,3 +100,21 @@ fn test_deref_bufmut_forwards() {
     (Box::new(Special) as Box<dyn BufMut>).put_u8(b'x');
     Box::new(Special).put_u8(b'x');
 }
+
+#[test]
+#[should_panic]
+fn write_byte_panics_if_out_of_bounds() {
+    let mut data = [b'b', b'a', b'r'];
+
+    let slice = unsafe { UninitSlice::from_raw_parts_mut(data.as_mut_ptr(), 3) };
+    slice.write_byte(4, b'f');
+}
+
+#[test]
+#[should_panic]
+fn write_slice_panics_if_different_length() {
+    let mut data = [b'b', b'a', b'r'];
+
+    let slice = unsafe { UninitSlice::from_raw_parts_mut(data.as_mut_ptr(), 3) };
+    slice.write_slice(b"a");
+}

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -112,9 +112,18 @@ fn write_byte_panics_if_out_of_bounds() {
 
 #[test]
 #[should_panic]
-fn write_slice_panics_if_different_length() {
+fn copy_from_slice_panics_if_different_length_1() {
     let mut data = [b'b', b'a', b'r'];
 
     let slice = unsafe { UninitSlice::from_raw_parts_mut(data.as_mut_ptr(), 3) };
-    slice.write_slice(b"a");
+    slice.copy_from_slice(b"a");
+}
+
+#[test]
+#[should_panic]
+fn copy_from_slice_panics_if_different_length_2() {
+    let mut data = [b'b', b'a', b'r'];
+
+    let slice = unsafe { UninitSlice::from_raw_parts_mut(data.as_mut_ptr(), 3) };
+    slice.copy_from_slice(b"abcd");
 }

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -912,12 +912,12 @@ fn bytes_buf_mut_advance() {
     let mut bytes = BytesMut::with_capacity(1024);
 
     unsafe {
-        let ptr = bytes.bytes_mut().as_ptr();
+        let ptr = bytes.bytes_mut().as_mut_ptr();
         assert_eq!(1024, bytes.bytes_mut().len());
 
         bytes.advance_mut(10);
 
-        let next = bytes.bytes_mut().as_ptr();
+        let next = bytes.bytes_mut().as_mut_ptr();
         assert_eq!(1024 - 10, bytes.bytes_mut().len());
         assert_eq!(ptr.offset(10), next);
 


### PR DESCRIPTION
The way `BufMut` uses `MaybeUninit` can lead to unsoundness.

This replaces `MaybeUnit` with a type owned by `bytes` so we can ensure the usage patterns are sound.

Refs: #328