### PR TITLE
remove `new` fns from combinator structs

### DIFF
--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -38,7 +38,7 @@ pub struct Chain<T, U> {
 
 impl<T, U> Chain<T, U> {
     /// Creates a new `Chain` sequencing the provided values.
-    pub fn new(a: T, b: U) -> Chain<T, U> {
+    pub(crate) fn new(a: T, b: U) -> Chain<T, U> {
         Chain { a, b }
     }
 

--- a/src/buf/iter.rs
+++ b/src/buf/iter.rs
@@ -34,17 +34,16 @@ impl<T> IntoIter<T> {
     ///
     /// ```
     /// use bytes::Bytes;
-    /// use bytes::buf::IntoIter;
     ///
     /// let buf = Bytes::from_static(b"abc");
-    /// let mut iter = IntoIter::new(buf);
+    /// let mut iter = buf.into_iter();
     ///
     /// assert_eq!(iter.next(), Some(b'a'));
     /// assert_eq!(iter.next(), Some(b'b'));
     /// assert_eq!(iter.next(), Some(b'c'));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn new(inner: T) -> IntoIter<T> {
+    pub(crate) fn new(inner: T) -> IntoIter<T> {
         IntoIter { inner }
     }
 


### PR DESCRIPTION
This is not idiomatic.