### PR TITLE
De-emphasize `Arc` implementation in `Bytes` description

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -10,7 +10,7 @@ use crate::loom::sync::atomic::AtomicMut;
 use crate::loom::sync::atomic::{self, AtomicPtr, AtomicUsize, Ordering};
 use crate::Buf;
 
-/// A cheeply cloneable and sliceable chunk of contiguous memory.
+/// A cheaply cloneable and sliceable chunk of contiguous memory.
 ///
 /// `Bytes` is an efficient container for storing and operating on contiguous
 /// slices of memory. It is intended for use primarily in networking code, but
@@ -24,7 +24,7 @@ use crate::Buf;
 /// implementations of `Bytes`.
 ///
 /// All `Bytes` implementations must fulfill the following requirements:
-/// - They are cheeply cloneable and thereby shareable between an unlimited amount
+/// - They are cheaply cloneable and thereby shareable between an unlimited amount
 ///   of components, for example by modifying a reference count.
 /// - Instances can be sliced to refer to a subset of the the original buffer.
 ///


### PR DESCRIPTION
The previous description focussed a lot on the `Arc` based implementation
of `Bytes`. Given the vtable based implemetation, this is however not the
only valid implementation. This changes the description a bit in order
to de-emaphasize the `Arc` part, and to describe that other implementations
are possible.

This should also be necessary if the vtable gets public.