### PR TITLE
Simplify <Vec<u8> as BufMut>::bytes_mut()

### DIFF
--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -1034,15 +1034,15 @@ unsafe impl BufMut for Vec<u8> {
 
     #[inline]
     fn bytes_mut(&mut self) -> &mut UninitSlice {
-        if self.capacity() == self.len() {
+        let len = self.len();
+        if self.capacity() == len {
             self.reserve(64); // Grow the vec
         }
 
         let cap = self.capacity();
-        let len = self.len();
 
         let ptr = self.as_mut_ptr();
-        unsafe { &mut UninitSlice::from_raw_parts_mut(ptr, cap)[len..] }
+        unsafe { UninitSlice::from_raw_parts_mut(ptr.offset(len as isize), cap - len) }
     }
 
     // Specialize these methods so they can skip checking `remaining_mut`


### PR DESCRIPTION
Removes a call to UninitMut indexing, which can panic, from
`Vec::<u8>::bytes_mut()`.  I came across this while looking at a
performance issue encountered after moving to bytes 0.6. This change
makes a microbenchmark in `prost` slightly faster, although there's
still a big delta between 0.5 and 0.6. See danburkert/prost#381.