### PR TITLE
remove unused Buf implementation.

### DIFF
--- a/benches/buf.rs
+++ b/benches/buf.rs
@@ -159,7 +159,6 @@ macro_rules! bench_group {
 mod get_u8 {
     use super::*;
     bench_group!(get_u8);
-    bench!(option, option);
 }
 mod get_u16 {
     use super::*;

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -1032,35 +1032,6 @@ impl Buf for &[u8] {
     }
 }
 
-impl Buf for Option<[u8; 1]> {
-    fn remaining(&self) -> usize {
-        if self.is_some() {
-            1
-        } else {
-            0
-        }
-    }
-
-    fn bytes(&self) -> &[u8] {
-        self.as_ref()
-            .map(AsRef::as_ref)
-            .unwrap_or(Default::default())
-    }
-
-    fn advance(&mut self, cnt: usize) {
-        if cnt == 0 {
-            return;
-        }
-
-        if self.is_none() {
-            panic!("overflow");
-        } else {
-            assert_eq!(1, cnt);
-            *self = None;
-        }
-    }
-}
-
 #[cfg(feature = "std")]
 impl<T: AsRef<[u8]>> Buf for std::io::Cursor<T> {
     fn remaining(&self) -> usize {


### PR DESCRIPTION
The implementation of `Buf` for `Option<[u8; 1]>` was added to support
`IntoBuf`. The `IntoBuf` trait has since been removed.

Closes #444