### PR TITLE
Rename Buf/BufMut, methods to chunk/chunk_mut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  nightly: nightly-2020-09-21
+  nightly: nightly-2020-12-17
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  nightly: nightly-2020-12-18
+  nightly: nightly-2020-09-21
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
-        run: rustup update nightly && rustup default nightly
+        run: rustup update stable && rustup default stable
       - name: Install rust-src
         run: rustup component add rust-src
       - name: ASAN / TSAN

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
+  nightly: nightly-2020-12-18
 
 defaults:
   run:
@@ -120,7 +121,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
-        run: rustup update stable && rustup default stable
+        run: rustup update $nightly && rustup default $nightly
       - name: Install rust-src
         run: rustup component add rust-src
       - name: ASAN / TSAN

--- a/benches/buf.rs
+++ b/benches/buf.rs
@@ -53,7 +53,7 @@ impl Buf for TestBuf {
         assert!(self.pos <= self.buf.len());
         self.next_readlen();
     }
-    fn bytes(&self) -> &[u8] {
+    fn chunk(&self) -> &[u8] {
         if self.readlen == 0 {
             Default::default()
         } else {
@@ -87,8 +87,8 @@ impl Buf for TestBufC {
         self.inner.advance(cnt)
     }
     #[inline(never)]
-    fn bytes(&self) -> &[u8] {
-        self.inner.bytes()
+    fn chunk(&self) -> &[u8] {
+        self.inner.chunk()
     }
 }
 

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -16,7 +16,7 @@ macro_rules! buf_get_impl {
         // this Option<ret> trick is to avoid keeping a borrow on self
         // when advance() is called (mut borrow) and to call bytes() only once
         let ret = $this
-            .bytes()
+            .chunk()
             .get(..SIZE)
             .map(|src| unsafe { $typ::$conv(*(src as *const _ as *const [_; SIZE])) });
 
@@ -78,7 +78,7 @@ pub trait Buf {
     /// the buffer.
     ///
     /// This value is greater than or equal to the length of the slice returned
-    /// by `bytes`.
+    /// by `chunk()`.
     ///
     /// # Examples
     ///
@@ -115,31 +115,31 @@ pub trait Buf {
     ///
     /// let mut buf = &b"hello world"[..];
     ///
-    /// assert_eq!(buf.bytes(), &b"hello world"[..]);
+    /// assert_eq!(buf.chunk(), &b"hello world"[..]);
     ///
     /// buf.advance(6);
     ///
-    /// assert_eq!(buf.bytes(), &b"world"[..]);
+    /// assert_eq!(buf.chunk(), &b"world"[..]);
     /// ```
     ///
     /// # Implementer notes
     ///
     /// This function should never panic. Once the end of the buffer is reached,
-    /// i.e., `Buf::remaining` returns 0, calls to `bytes` should return an
+    /// i.e., `Buf::remaining` returns 0, calls to `chunk()` should return an
     /// empty slice.
-    fn bytes(&self) -> &[u8];
+    fn chunk(&self) -> &[u8];
 
     /// Fills `dst` with potentially multiple slices starting at `self`'s
     /// current position.
     ///
-    /// If the `Buf` is backed by disjoint slices of bytes, `bytes_vectored` enables
+    /// If the `Buf` is backed by disjoint slices of bytes, `chunk_vectored` enables
     /// fetching more than one slice at once. `dst` is a slice of `IoSlice`
     /// references, enabling the slice to be directly used with [`writev`]
     /// without any further conversion. The sum of the lengths of all the
     /// buffers in `dst` will be less than or equal to `Buf::remaining()`.
     ///
     /// The entries in `dst` will be overwritten, but the data **contained** by
-    /// the slices **will not** be modified. If `bytes_vectored` does not fill every
+    /// the slices **will not** be modified. If `chunk_vectored` does not fill every
     /// entry in `dst`, then `dst` is guaranteed to contain all remaining slices
     /// in `self.
     ///
@@ -149,7 +149,7 @@ pub trait Buf {
     /// # Implementer notes
     ///
     /// This function should never panic. Once the end of the buffer is reached,
-    /// i.e., `Buf::remaining` returns 0, calls to `bytes_vectored` must return 0
+    /// i.e., `Buf::remaining` returns 0, calls to `chunk_vectored` must return 0
     /// without mutating `dst`.
     ///
     /// Implementations should also take care to properly handle being called
@@ -157,13 +157,13 @@ pub trait Buf {
     ///
     /// [`writev`]: http://man7.org/linux/man-pages/man2/readv.2.html
     #[cfg(feature = "std")]
-    fn bytes_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
+    fn chunk_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
         if dst.is_empty() {
             return 0;
         }
 
         if self.has_remaining() {
-            dst[0] = IoSlice::new(self.bytes());
+            dst[0] = IoSlice::new(self.chunk());
             1
         } else {
             0
@@ -172,7 +172,7 @@ pub trait Buf {
 
     /// Advance the internal cursor of the Buf
     ///
-    /// The next call to `bytes` will return a slice starting `cnt` bytes
+    /// The next call to `chunk()` will return a slice starting `cnt` bytes
     /// further into the underlying buffer.
     ///
     /// # Examples
@@ -182,11 +182,11 @@ pub trait Buf {
     ///
     /// let mut buf = &b"hello world"[..];
     ///
-    /// assert_eq!(buf.bytes(), &b"hello world"[..]);
+    /// assert_eq!(buf.chunk(), &b"hello world"[..]);
     ///
     /// buf.advance(6);
     ///
-    /// assert_eq!(buf.bytes(), &b"world"[..]);
+    /// assert_eq!(buf.chunk(), &b"world"[..]);
     /// ```
     ///
     /// # Panics
@@ -253,7 +253,7 @@ pub trait Buf {
             let cnt;
 
             unsafe {
-                let src = self.bytes();
+                let src = self.chunk();
                 cnt = cmp::min(src.len(), dst.len() - off);
 
                 ptr::copy_nonoverlapping(src.as_ptr(), dst[off..].as_mut_ptr(), cnt);
@@ -283,7 +283,7 @@ pub trait Buf {
     /// This function panics if there is no more remaining data in `self`.
     fn get_u8(&mut self) -> u8 {
         assert!(self.remaining() >= 1);
-        let ret = self.bytes()[0];
+        let ret = self.chunk()[0];
         self.advance(1);
         ret
     }
@@ -306,7 +306,7 @@ pub trait Buf {
     /// This function panics if there is no more remaining data in `self`.
     fn get_i8(&mut self) -> i8 {
         assert!(self.remaining() >= 1);
-        let ret = self.bytes()[0] as i8;
+        let ret = self.chunk()[0] as i8;
         self.advance(1);
         ret
     }
@@ -861,7 +861,7 @@ pub trait Buf {
     /// let mut chain = b"hello "[..].chain(&b"world"[..]);
     ///
     /// let full = chain.copy_to_bytes(11);
-    /// assert_eq!(full.bytes(), b"hello world");
+    /// assert_eq!(full.chunk(), b"hello world");
     /// ```
     fn chain<U: Buf>(self, next: U) -> Chain<Self, U>
     where
@@ -908,13 +908,13 @@ macro_rules! deref_forward_buf {
             (**self).remaining()
         }
 
-        fn bytes(&self) -> &[u8] {
-            (**self).bytes()
+        fn chunk(&self) -> &[u8] {
+            (**self).chunk()
         }
 
         #[cfg(feature = "std")]
-        fn bytes_vectored<'b>(&'b self, dst: &mut [IoSlice<'b>]) -> usize {
-            (**self).bytes_vectored(dst)
+        fn chunk_vectored<'b>(&'b self, dst: &mut [IoSlice<'b>]) -> usize {
+            (**self).chunk_vectored(dst)
         }
 
         fn advance(&mut self, cnt: usize) {
@@ -1022,7 +1022,7 @@ impl Buf for &[u8] {
     }
 
     #[inline]
-    fn bytes(&self) -> &[u8] {
+    fn chunk(&self) -> &[u8] {
         self
     }
 
@@ -1045,7 +1045,7 @@ impl<T: AsRef<[u8]>> Buf for std::io::Cursor<T> {
         len - pos as usize
     }
 
-    fn bytes(&self) -> &[u8] {
+    fn chunk(&self) -> &[u8] {
         let len = self.get_ref().as_ref().len();
         let pos = self.position();
 

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -157,7 +157,7 @@ pub trait Buf {
     ///
     /// [`writev`]: http://man7.org/linux/man-pages/man2/readv.2.html
     #[cfg(feature = "std")]
-    fn chunk_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
+    fn chunks_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
         if dst.is_empty() {
             return 0;
         }
@@ -913,8 +913,8 @@ macro_rules! deref_forward_buf {
         }
 
         #[cfg(feature = "std")]
-        fn chunk_vectored<'b>(&'b self, dst: &mut [IoSlice<'b>]) -> usize {
-            (**self).chunk_vectored(dst)
+        fn chunks_vectored<'b>(&'b self, dst: &mut [IoSlice<'b>]) -> usize {
+            (**self).chunks_vectored(dst)
         }
 
         fn advance(&mut self, cnt: usize) {

--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -165,9 +165,9 @@ where
     }
 
     #[cfg(feature = "std")]
-    fn chunk_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
-        let mut n = self.a.chunk_vectored(dst);
-        n += self.b.chunk_vectored(&mut dst[n..]);
+    fn chunks_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
+        let mut n = self.a.chunks_vectored(dst);
+        n += self.b.chunks_vectored(&mut dst[n..]);
         n
     }
 }

--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -138,11 +138,11 @@ where
         self.a.remaining() + self.b.remaining()
     }
 
-    fn bytes(&self) -> &[u8] {
+    fn chunk(&self) -> &[u8] {
         if self.a.has_remaining() {
-            self.a.bytes()
+            self.a.chunk()
         } else {
-            self.b.bytes()
+            self.b.chunk()
         }
     }
 
@@ -165,9 +165,9 @@ where
     }
 
     #[cfg(feature = "std")]
-    fn bytes_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
-        let mut n = self.a.bytes_vectored(dst);
-        n += self.b.bytes_vectored(&mut dst[n..]);
+    fn chunk_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
+        let mut n = self.a.chunk_vectored(dst);
+        n += self.b.chunk_vectored(&mut dst[n..]);
         n
     }
 }
@@ -181,11 +181,11 @@ where
         self.a.remaining_mut() + self.b.remaining_mut()
     }
 
-    fn bytes_mut(&mut self) -> &mut UninitSlice {
+    fn chunk_mut(&mut self) -> &mut UninitSlice {
         if self.a.has_remaining_mut() {
-            self.a.bytes_mut()
+            self.a.chunk_mut()
         } else {
-            self.b.bytes_mut()
+            self.b.chunk_mut()
         }
     }
 

--- a/src/buf/iter.rs
+++ b/src/buf/iter.rs
@@ -117,7 +117,7 @@ impl<T: Buf> Iterator for IntoIter<T> {
             return None;
         }
 
-        let b = self.inner.bytes()[0];
+        let b = self.inner.chunk()[0];
         self.inner.advance(1);
 
         Some(b)

--- a/src/buf/limit.rs
+++ b/src/buf/limit.rs
@@ -61,8 +61,8 @@ unsafe impl<T: BufMut> BufMut for Limit<T> {
         cmp::min(self.inner.remaining_mut(), self.limit)
     }
 
-    fn bytes_mut(&mut self) -> &mut UninitSlice {
-        let bytes = self.inner.bytes_mut();
+    fn chunk_mut(&mut self) -> &mut UninitSlice {
+        let bytes = self.inner.chunk_mut();
         let end = cmp::min(bytes.len(), self.limit);
         &mut bytes[..end]
     }

--- a/src/buf/reader.rs
+++ b/src/buf/reader.rs
@@ -73,7 +73,7 @@ impl<B: Buf + Sized> io::Read for Reader<B> {
 
 impl<B: Buf + Sized> io::BufRead for Reader<B> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
-        Ok(self.buf.bytes())
+        Ok(self.buf.chunk())
     }
     fn consume(&mut self, amt: usize) {
         self.buf.advance(amt)

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -134,8 +134,8 @@ impl<T: Buf> Buf for Take<T> {
         cmp::min(self.inner.remaining(), self.limit)
     }
 
-    fn bytes(&self) -> &[u8] {
-        let bytes = self.inner.bytes();
+    fn chunk(&self) -> &[u8] {
+        let bytes = self.inner.chunk();
         &bytes[..cmp::min(bytes.len(), self.limit)]
     }
 

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -6,7 +6,7 @@ use core::ops::{
 
 /// Uninitialized byte slice.
 ///
-/// Returned by `BufMut::bytes_mut()`, the referenced byte slice may be
+/// Returned by `BufMut::chunk_mut()`, the referenced byte slice may be
 /// uninitialized. The wrapper provides safe access without introducing
 /// undefined behavior.
 ///
@@ -114,7 +114,7 @@ impl UninitSlice {
     ///
     /// let mut data = [0, 1, 2];
     /// let mut slice = &mut data[..];
-    /// let ptr = BufMut::bytes_mut(&mut slice).as_mut_ptr();
+    /// let ptr = BufMut::chunk_mut(&mut slice).as_mut_ptr();
     /// ```
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.0.as_mut_ptr() as *mut _
@@ -129,7 +129,7 @@ impl UninitSlice {
     ///
     /// let mut data = [0, 1, 2];
     /// let mut slice = &mut data[..];
-    /// let len = BufMut::bytes_mut(&mut slice).len();
+    /// let len = BufMut::chunk_mut(&mut slice).len();
     ///
     /// assert_eq!(len, 3);
     /// ```

--- a/src/buf/vec_deque.rs
+++ b/src/buf/vec_deque.rs
@@ -7,7 +7,7 @@ impl Buf for VecDeque<u8> {
         self.len()
     }
 
-    fn bytes(&self) -> &[u8] {
+    fn chunk(&self) -> &[u8] {
         let (s1, s2) = self.as_slices();
         if s1.is_empty() {
             s2

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -530,7 +530,7 @@ impl Buf for Bytes {
     }
 
     #[inline]
-    fn bytes(&self) -> &[u8] {
+    fn chunk(&self) -> &[u8] {
         self.as_slice()
     }
 

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -445,7 +445,7 @@ impl BytesMut {
             let additional = new_len - len;
             self.reserve(additional);
             unsafe {
-                let dst = self.bytes_mut().as_mut_ptr();
+                let dst = self.chunk_mut().as_mut_ptr();
                 ptr::write_bytes(dst, value, additional);
                 self.set_len(new_len);
             }
@@ -944,7 +944,7 @@ impl Buf for BytesMut {
     }
 
     #[inline]
-    fn bytes(&self) -> &[u8] {
+    fn chunk(&self) -> &[u8] {
         self.as_slice()
     }
 
@@ -985,7 +985,7 @@ unsafe impl BufMut for BytesMut {
     }
 
     #[inline]
-    fn bytes_mut(&mut self) -> &mut UninitSlice {
+    fn chunk_mut(&mut self) -> &mut UninitSlice {
         if self.capacity() == self.len() {
             self.reserve(64);
         }
@@ -1000,7 +1000,7 @@ unsafe impl BufMut for BytesMut {
         Self: Sized,
     {
         while src.has_remaining() {
-            let s = src.bytes();
+            let s = src.chunk();
             let l = s.len();
             self.extend_from_slice(s);
             src.advance(l);

--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -9,17 +9,17 @@ fn test_fresh_cursor_vec() {
     let mut buf = &b"hello"[..];
 
     assert_eq!(buf.remaining(), 5);
-    assert_eq!(buf.bytes(), b"hello");
+    assert_eq!(buf.chunk(), b"hello");
 
     buf.advance(2);
 
     assert_eq!(buf.remaining(), 3);
-    assert_eq!(buf.bytes(), b"llo");
+    assert_eq!(buf.chunk(), b"llo");
 
     buf.advance(3);
 
     assert_eq!(buf.remaining(), 0);
-    assert_eq!(buf.bytes(), b"");
+    assert_eq!(buf.chunk(), b"");
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn test_bufs_vec() {
 
     let mut dst = [IoSlice::new(b1), IoSlice::new(b2)];
 
-    assert_eq!(1, buf.bytes_vectored(&mut dst[..]));
+    assert_eq!(1, buf.chunk_vectored(&mut dst[..]));
 }
 
 #[test]
@@ -63,9 +63,9 @@ fn test_vec_deque() {
     let mut buffer: VecDeque<u8> = VecDeque::new();
     buffer.extend(b"hello world");
     assert_eq!(11, buffer.remaining());
-    assert_eq!(b"hello world", buffer.bytes());
+    assert_eq!(b"hello world", buffer.chunk());
     buffer.advance(6);
-    assert_eq!(b"world", buffer.bytes());
+    assert_eq!(b"world", buffer.chunk());
     buffer.extend(b" piece");
     let mut out = [0; 11];
     buffer.copy_to_slice(&mut out);
@@ -81,8 +81,8 @@ fn test_deref_buf_forwards() {
             unreachable!("remaining");
         }
 
-        fn bytes(&self) -> &[u8] {
-            unreachable!("bytes");
+        fn chunk(&self) -> &[u8] {
+            unreachable!("chunk");
         }
 
         fn advance(&mut self, _: usize) {

--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -53,7 +53,7 @@ fn test_bufs_vec() {
 
     let mut dst = [IoSlice::new(b1), IoSlice::new(b2)];
 
-    assert_eq!(1, buf.chunk_vectored(&mut dst[..]));
+    assert_eq!(1, buf.chunks_vectored(&mut dst[..]));
 }
 
 #[test]

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -11,7 +11,7 @@ fn test_vec_as_mut_buf() {
 
     assert_eq!(buf.remaining_mut(), usize::MAX);
 
-    assert!(buf.bytes_mut().len() >= 64);
+    assert!(buf.chunk_mut().len() >= 64);
 
     buf.put(&b"zomg"[..]);
 
@@ -81,8 +81,8 @@ fn test_deref_bufmut_forwards() {
             unreachable!("remaining_mut");
         }
 
-        fn bytes_mut(&mut self) -> &mut UninitSlice {
-            unreachable!("bytes_mut");
+        fn chunk_mut(&mut self) -> &mut UninitSlice {
+            unreachable!("chunk_mut");
         }
 
         unsafe fn advance_mut(&mut self, _: usize) {

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -912,20 +912,20 @@ fn bytes_buf_mut_advance() {
     let mut bytes = BytesMut::with_capacity(1024);
 
     unsafe {
-        let ptr = bytes.bytes_mut().as_mut_ptr();
-        assert_eq!(1024, bytes.bytes_mut().len());
+        let ptr = bytes.chunk_mut().as_mut_ptr();
+        assert_eq!(1024, bytes.chunk_mut().len());
 
         bytes.advance_mut(10);
 
-        let next = bytes.bytes_mut().as_mut_ptr();
-        assert_eq!(1024 - 10, bytes.bytes_mut().len());
+        let next = bytes.chunk_mut().as_mut_ptr();
+        assert_eq!(1024 - 10, bytes.chunk_mut().len());
         assert_eq!(ptr.offset(10), next);
 
         // advance to the end
         bytes.advance_mut(1024 - 10);
 
         // The buffer size is doubled
-        assert_eq!(1024, bytes.bytes_mut().len());
+        assert_eq!(1024, bytes.chunk_mut().len());
     }
 }
 

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -62,7 +62,7 @@ fn vectored_read() {
             IoSlice::new(b4),
         ];
 
-        assert_eq!(2, buf.bytes_vectored(&mut iovecs));
+        assert_eq!(2, buf.chunk_vectored(&mut iovecs));
         assert_eq!(iovecs[0][..], b"hello"[..]);
         assert_eq!(iovecs[1][..], b"world"[..]);
         assert_eq!(iovecs[2][..], b""[..]);
@@ -83,7 +83,7 @@ fn vectored_read() {
             IoSlice::new(b4),
         ];
 
-        assert_eq!(2, buf.bytes_vectored(&mut iovecs));
+        assert_eq!(2, buf.chunk_vectored(&mut iovecs));
         assert_eq!(iovecs[0][..], b"llo"[..]);
         assert_eq!(iovecs[1][..], b"world"[..]);
         assert_eq!(iovecs[2][..], b""[..]);
@@ -104,7 +104,7 @@ fn vectored_read() {
             IoSlice::new(b4),
         ];
 
-        assert_eq!(1, buf.bytes_vectored(&mut iovecs));
+        assert_eq!(1, buf.chunk_vectored(&mut iovecs));
         assert_eq!(iovecs[0][..], b"world"[..]);
         assert_eq!(iovecs[1][..], b""[..]);
         assert_eq!(iovecs[2][..], b""[..]);
@@ -125,7 +125,7 @@ fn vectored_read() {
             IoSlice::new(b4),
         ];
 
-        assert_eq!(1, buf.bytes_vectored(&mut iovecs));
+        assert_eq!(1, buf.chunk_vectored(&mut iovecs));
         assert_eq!(iovecs[0][..], b"ld"[..]);
         assert_eq!(iovecs[1][..], b""[..]);
         assert_eq!(iovecs[2][..], b""[..]);

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -62,7 +62,7 @@ fn vectored_read() {
             IoSlice::new(b4),
         ];
 
-        assert_eq!(2, buf.chunk_vectored(&mut iovecs));
+        assert_eq!(2, buf.chunks_vectored(&mut iovecs));
         assert_eq!(iovecs[0][..], b"hello"[..]);
         assert_eq!(iovecs[1][..], b"world"[..]);
         assert_eq!(iovecs[2][..], b""[..]);
@@ -83,7 +83,7 @@ fn vectored_read() {
             IoSlice::new(b4),
         ];
 
-        assert_eq!(2, buf.chunk_vectored(&mut iovecs));
+        assert_eq!(2, buf.chunks_vectored(&mut iovecs));
         assert_eq!(iovecs[0][..], b"llo"[..]);
         assert_eq!(iovecs[1][..], b"world"[..]);
         assert_eq!(iovecs[2][..], b""[..]);
@@ -104,7 +104,7 @@ fn vectored_read() {
             IoSlice::new(b4),
         ];
 
-        assert_eq!(1, buf.chunk_vectored(&mut iovecs));
+        assert_eq!(1, buf.chunks_vectored(&mut iovecs));
         assert_eq!(iovecs[0][..], b"world"[..]);
         assert_eq!(iovecs[1][..], b""[..]);
         assert_eq!(iovecs[2][..], b""[..]);
@@ -125,7 +125,7 @@ fn vectored_read() {
             IoSlice::new(b4),
         ];
 
-        assert_eq!(1, buf.chunk_vectored(&mut iovecs));
+        assert_eq!(1, buf.chunks_vectored(&mut iovecs));
         assert_eq!(iovecs[0][..], b"ld"[..]);
         assert_eq!(iovecs[1][..], b""[..]);
         assert_eq!(iovecs[2][..], b""[..]);

--- a/tests/test_take.rs
+++ b/tests/test_take.rs
@@ -8,5 +8,5 @@ fn long_take() {
     // overrun the buffer. Regression test for #138.
     let buf = b"hello world".take(100);
     assert_eq!(11, buf.remaining());
-    assert_eq!(b"hello world", buf.bytes());
+    assert_eq!(b"hello world", buf.chunk());
 }


### PR DESCRIPTION
The `bytes()` / `bytes_mut()` name implies the method returns the full
set of bytes represented by `Buf`/`BufMut`. To rectify this, the methods
are renamed to `chunk()` and `chunk_mut()` to reflect the partial nature
of the returned byte slice.

Additionally, `bytes_vectored()` is renamed `chunk_vectored()`.

Closes #447