### PR TITLE
avoid mem-forget-in-disguise

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -806,8 +806,7 @@ impl From<Vec<u8>> for Bytes {
 
         let slice = vec.into_boxed_slice();
         let len = slice.len();
-        let ptr = slice.as_ptr();
-        drop(Box::into_raw(slice));
+        let ptr = Box::into_raw(slice) as *mut u8;
 
         if ptr as usize & 0x1 == 0 {
             let data = ptr as usize | KIND_VEC;


### PR DESCRIPTION
`Box::into_raw(slice)` (which is used just as a way to encode `mem::forget` here, from what I can tell) uses the `Box` and thus asserts its uniqueness as a pointer, which is not compatible with what the code here does. That's why the docs recommend `ManuallyDrop` over `mem::forget`. This adjusts the code accordingly.

I found this with Miri using the `-Zmiri-track-raw-pointers` flag. Unfortunately, the test suite cannot pass with that flag since `bytes` uses int-to-ptr casts, which are incompatible with `-Zmiri-track-raw-pointers`. But this fix seems worth landing nevertheless.