### PR TITLE
add inline for put_slice

### DIFF
--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -1047,7 +1047,6 @@ unsafe impl BufMut for Vec<u8> {
 
     // Specialize these methods so they can skip checking `remaining_mut`
     // and `advance_mut`.
-
     fn put<T: super::Buf>(&mut self, mut src: T)
     where
         Self: Sized,
@@ -1069,6 +1068,7 @@ unsafe impl BufMut for Vec<u8> {
         }
     }
 
+    #[inline]
     fn put_slice(&mut self, src: &[u8]) {
         self.extend_from_slice(src);
     }


### PR DESCRIPTION
 it will hurt a lot performance for methods like `BufMut::put_u8/i8` without inline. We have a test in https://github.com/sunli829/colfer-rs .

without inline,  the encode bench needs 0.612s, with inline, the time reduce to 0.362s. 

