### PR TITLE
Prepare 1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.0.1 (January 11, 2021)
+
+### Changed
+- mark `Vec::put_slice` with `#[inline]` (#459)
+
+### Fixed
+- Fix deprecation warning (#457)
+- use `Box::into_raw` instead of `mem::forget`-in-disguise (#458)
+
 # 1.0.0 (December 22, 2020)
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,14 @@ name = "bytes"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v1.0.x" git tag.
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = [
     "Carl Lerche <me@carllerche.com>",
     "Sean McArthur <sean@seanmonstar.com>",
 ]
 description = "Types and traits for working with bytes"
-documentation = "https://docs.rs/bytes/1.0.0/bytes/"
+documentation = "https://docs.rs/bytes/1.0.1/bytes/"
 repository = "https://github.com/tokio-rs/bytes"
 readme = "README.md"
 keywords = ["buffers", "zero-copy", "io"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
-#![doc(html_root_url = "https://docs.rs/bytes/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/bytes/1.0.1")]
 #![no_std]
 
 //! Provides abstractions for working with bytes.


### PR DESCRIPTION
# 1.0.1 (January 11, 2021)

### Changed
- mark `Vec::put_slice` with `#[inline]` (#459)

### Fixed
- Fix deprecation warning (#457)
- use `Box::into_raw` instead of `mem::forget`-in-disguise (#458)