### PR TITLE
docs: Fix broken Take link

### DIFF
--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -5,7 +5,7 @@ use core::cmp;
 /// A `Buf` adapter which limits the bytes read from an underlying buffer.
 ///
 /// This struct is generally created by calling `take()` on `Buf`. See
-/// documentation of [`take()`](trait.BufExt.html#method.take) for more details.
+/// documentation of [`take()`](trait.Buf.html#method.take) for more details.
 #[derive(Debug)]
 pub struct Take<T> {
     inner: T,


### PR DESCRIPTION
The [1.0.1 docs](https://docs.rs/bytes/1.0.1/bytes/buf/struct.Take.html) for `bytes::buf::Take` include a link to `bytes::buf::BufExt`. However, this trait no longer exists in version 1.0.1, and the link should point to the `take()` function associated with `bytes::buf::Buf`.

This PR updates the link.