### PR TITLE
Return more chunks from Take::chunks_vectored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Fixed
+- `Take::chunks_vectored` returns as much as possible.
+
 # 1.0.1 (January 11, 2021)
 
 ### Changed

--- a/tests/test_take.rs
+++ b/tests/test_take.rs
@@ -1,5 +1,8 @@
 #![warn(rust_2018_idioms)]
 
+#[cfg(feature = "std")]
+use std::io::IoSlice;
+
 use bytes::buf::Buf;
 
 #[test]
@@ -9,4 +12,51 @@ fn long_take() {
     let buf = b"hello world".take(100);
     assert_eq!(11, buf.remaining());
     assert_eq!(b"hello world", buf.chunk());
+}
+
+// Provide a buf with two slices.
+#[cfg(feature = "std")]
+fn chained() -> impl Buf {
+    let a: &[u8] = b"Hello ";
+    let b: &[u8] = b"World";
+    a.chain(b)
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn take_vectored_doesnt_fit() {
+    // When there are not enough io slices.
+    let mut slices = [IoSlice::new(&[]); 1];
+    let buf = chained().take(10);
+    assert_eq!(1, buf.chunks_vectored(&mut slices));
+    assert_eq!(b"Hello ", &slices[0] as &[u8]);
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn take_vectored_long() {
+    let mut slices = [IoSlice::new(&[]); 2];
+    let buf = chained().take(20);
+    assert_eq!(2, buf.chunks_vectored(&mut slices));
+    assert_eq!(b"Hello ", &slices[0] as &[u8]);
+    assert_eq!(b"World", &slices[1] as &[u8]);
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn take_vectored_many_slices() {
+    let mut slices = [IoSlice::new(&[]); 3];
+    let buf = chained().take(10);
+    assert_eq!(2, buf.chunks_vectored(&mut slices));
+    assert_eq!(b"Hello ", &slices[0] as &[u8]);
+    assert_eq!(b"Worl", &slices[1] as &[u8]);
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn take_vectored_short() {
+    let mut slices = [IoSlice::new(&[]); 3];
+    let buf = chained().take(3);
+    assert_eq!(1, buf.chunks_vectored(&mut slices));
+    assert_eq!(b"Hel", &slices[0] as &[u8]);
 }


### PR DESCRIPTION
Specialize the `Take`s implementation of the method so it can return as
many chunks as possible, instead of the default 1.

Implements #474.

(I'm not marking it „Closes“, as there's still the open question if the guarantee in the documentation should be relaxed; I think this makes sense even if it gets relaxed because it allows for more optimal use of `write_vectored` and similar).