### PR TITLE
Optimize {Take,Chain}::copy_to_bytes

### DIFF
--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -1,5 +1,5 @@
 use crate::buf::{IntoIter, UninitSlice};
-use crate::{Buf, BufMut};
+use crate::{Buf, BufMut, Bytes, BytesMut};
 
 #[cfg(feature = "std")]
 use std::io::IoSlice;
@@ -169,6 +169,22 @@ where
         let mut n = self.a.chunks_vectored(dst);
         n += self.b.chunks_vectored(&mut dst[n..]);
         n
+    }
+
+    fn copy_to_bytes(&mut self, len: usize) -> Bytes {
+        match self.a.remaining() {
+            0 => self.b.copy_to_bytes(len),
+            a_rem if a_rem >= len => self.a.copy_to_bytes(len),
+            a_rem => {
+                assert!(
+                    len <= a_rem + self.b.remaining(),
+                    "`len` greater than remaining"
+                );
+                let mut ret = BytesMut::with_capacity(len);
+                ret.put(self.take(len));
+                ret.freeze()
+            }
+        }
     }
 }
 

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -1,4 +1,4 @@
-use crate::Buf;
+use crate::{Buf, Bytes};
 
 use core::cmp;
 
@@ -143,5 +143,16 @@ impl<T: Buf> Buf for Take<T> {
         assert!(cnt <= self.limit);
         self.inner.advance(cnt);
         self.limit -= cnt;
+    }
+
+    fn copy_to_bytes(&mut self, len: usize) -> Bytes {
+        // The inner shall check its own limits too
+        assert!(len <= self.limit, "`len` greater than remaining");
+
+        let result = self.inner.copy_to_bytes(len);
+        // Update it by the size actually consumed (in case it is shorter and opts to consume the
+        // rest instead of panicking)
+        self.limit -= result.len();
+        result
     }
 }

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -132,3 +132,14 @@ fn vectored_read() {
         assert_eq!(iovecs[3][..], b""[..]);
     }
 }
+
+#[test]
+fn copy_to_bytes() {
+    let a = Bytes::from(&b"hello"[..]);
+    let b = Bytes::from(&b"world"[..]);
+
+    let mut buf = a.chain(b);
+    assert_eq!(&b"hell"[..], buf.copy_to_bytes(4));
+    assert_eq!(&b"ow"[..], buf.copy_to_bytes(2));
+    assert_eq!(&b"orld"[..], buf.copy_to_bytes(4));
+}

--- a/tests/test_take.rs
+++ b/tests/test_take.rs
@@ -1,6 +1,9 @@
 #![warn(rust_2018_idioms)]
 
+use std::ptr;
+
 use bytes::buf::Buf;
+use bytes::Bytes;
 
 #[test]
 fn long_take() {
@@ -9,4 +12,12 @@ fn long_take() {
     let buf = b"hello world".take(100);
     assert_eq!(11, buf.remaining());
     assert_eq!(b"hello world", buf.chunk());
+}
+
+#[test]
+fn copy_to_bytes() {
+    let mut buf = Bytes::from("Hello World").take(8);
+    let buf_ptr = buf.chunk().as_ptr();
+    let copied = buf.copy_to_bytes(4);
+    assert!(ptr::eq(buf_ptr, copied.as_ptr()));
 }


### PR DESCRIPTION
Call to the inner implementation if possible, to take advantage of the
inner one possibly having an optimized (non-copying) version of
copy_to_bytes.

Closes #475.