### PR TITLE
Override put_slice for &mut [u8]

### DIFF
--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -1012,6 +1012,14 @@ unsafe impl BufMut for &mut [u8] {
         let (_, b) = core::mem::replace(self, &mut []).split_at_mut(cnt);
         *self = b;
     }
+
+    #[inline]
+    fn put_slice(&mut self, src: &[u8]) {
+        self[..src.len()].copy_from_slice(src);
+        unsafe {
+            self.advance_mut(src.len());
+        }
+    }
 }
 
 unsafe impl BufMut for Vec<u8> {

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -70,6 +70,9 @@ fn test_mut_slice() {
     let mut v = vec![0, 0, 0, 0];
     let mut s = &mut v[..];
     s.put_u32(42);
+
+    assert_eq!(s.len(), 0);
+    assert_eq!(&v, &[0, 0, 0, 42]);
 }
 
 #[test]


### PR DESCRIPTION
Noticed non optimal assembly generated when using `BufMut` with `&mut [u8]` slices.
[playground](https://play.rust-lang.org/?version=nightly&mode=release&edition=2018&gist=c6d23c716c6d1af91a242b821a7cfbce)

After further investigation add override for `put_slice` in `&mut [u8]` implementation.