### PR TITLE
Avoid extraneous call to remaining in get_u8/i8

### DIFF
--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -285,7 +285,7 @@ pub trait Buf {
     ///
     /// This function panics if there is no more remaining data in `self`.
     fn get_u8(&mut self) -> u8 {
-        assert!(self.remaining() >= 1);
+        assert!(self.chunk().len() >= 1);
         let ret = self.chunk()[0];
         self.advance(1);
         ret
@@ -308,7 +308,7 @@ pub trait Buf {
     ///
     /// This function panics if there is no more remaining data in `self`.
     fn get_i8(&mut self) -> i8 {
-        assert!(self.remaining() >= 1);
+        assert!(self.chunk().len() >= 1);
         let ret = self.chunk()[0] as i8;
         self.advance(1);
         ret


### PR DESCRIPTION
I have a chained datastructure that can dereference into a slice quite fast, but remaining requires walking the chain, which is relatively slow.

I would hazard a guess that this is the more common perf characteristic of non-contiguous impls of Buf. 

Separately, this brings these impls in line with all the other get_ impls, which have a fast path with [u8].get(...), which does the same bounds check that I do in this patch

I think clippy will say to use non_empty, here, I think in this case this is more clear, but I will do whatever is preferred.