### PR TITLE
Fully inline BytesMut::new

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1250,6 +1250,7 @@ impl Shared {
     }
 }
 
+#[inline]
 fn original_capacity_to_repr(cap: usize) -> usize {
     let width = PTR_WIDTH - ((cap >> MIN_ORIGINAL_CAPACITY_WIDTH).leading_zeros() as usize);
     cmp::min(
@@ -1476,6 +1477,7 @@ impl PartialEq<Bytes> for BytesMut {
     }
 }
 
+#[inline]
 fn vptr(ptr: *mut u8) -> NonNull<u8> {
     if cfg!(debug_assertions) {
         NonNull::new(ptr).expect("Vec pointer should be non-null")


### PR DESCRIPTION
For
```rust
pub fn foo() -> bytes::BytesMut {
    bytes::BytesMut::new()
}
```

Before:
```asm
playground::foo:
 push    r14
 push    rbx
 sub     rsp, 24
 mov     rbx, rdi
 mov     qword, ptr, [rsp], 1
 xorps   xmm0, xmm0
 movups  xmmword, ptr, [rsp, +, 8], xmm0
 mov     edi, 1
 call    qword, ptr, [rip, +, _ZN5bytes9bytes_mut4vptr17h9b64a3ca8a97f748E@GOTPCREL]
 mov     r14, rax
 xor     edi, edi
 call    qword, ptr, [rip, +, _ZN5bytes9bytes_mut25original_capacity_to_repr17h95b994b24f6347edE@GOTPCREL]
 lea     rax, [4*rax, +, 1]
 mov     qword, ptr, [rbx], r14
 xorps   xmm0, xmm0
 movups  xmmword, ptr, [rbx, +, 8], xmm0
 mov     qword, ptr, [rbx, +, 24], rax
 mov     rax, rbx
 add     rsp, 24
 pop     rbx
 pop     r14
 ret
.LBB1_2:
 mov     rbx, rax
 mov     rdi, rsp
 call    core::ptr::drop_in_place<alloc::vec::Vec<u8>>
 mov     rdi, rbx
 call    _Unwind_Resume
 ud2
```
After:
```asm
playground::foo:
 mov     rax, rdi
 mov     qword, ptr, [rdi], 1
 xorps   xmm0, xmm0
 movups  xmmword, ptr, [rdi, +, 8], xmm0
 mov     qword, ptr, [rdi, +, 24], 1
 ret
```