### PR TITLE
Use ubuntu-latest instead of ubuntu-16.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           - powerpc-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
           - wasm32-unknown-unknown
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust


### PR DESCRIPTION
Traditional 5-years support of Ubuntu 16.04 by Canonical ended in April, 2021, and GitHub Actions' `ubuntu-16.04` environment will be removed in September, 2021: https://github.com/actions/virtual-environments/issues/3287