### PR TITLE
Remove doc URLs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,7 @@
 
 name = "bytes"
 # When releasing to crates.io:
-# - Update html_root_url.
 # - Update CHANGELOG.md.
-# - Update doc URL.
 # - Create "v1.0.x" git tag.
 version = "1.0.1"
 license = "MIT"
@@ -13,7 +11,7 @@ authors = [
     "Sean McArthur <sean@seanmonstar.com>",
 ]
 description = "Types and traits for working with bytes"
-documentation = "https://docs.rs/bytes/1.0.1/bytes/"
+documentation = "https://docs.rs/bytes"
 repository = "https://github.com/tokio-rs/bytes"
 readme = "README.md"
 keywords = ["buffers", "zero-copy", "io"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ authors = [
     "Sean McArthur <sean@seanmonstar.com>",
 ]
 description = "Types and traits for working with bytes"
-documentation = "https://docs.rs/bytes"
 repository = "https://github.com/tokio-rs/bytes"
 readme = "README.md"
 keywords = ["buffers", "zero-copy", "io"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
-#![doc(html_root_url = "https://docs.rs/bytes/1.0.1")]
 #![no_std]
 
 //! Provides abstractions for working with bytes.


### PR DESCRIPTION
- Remove html_root_url
   html_root_url is not needed in most cases. And api-guidelines no longer recommends this. see also: https://github.com/tokio-rs/tokio/pull/3489
- Remove doc URL in Cargo.toml
   https://doc.rust-lang.org/cargo/reference/manifest.html#the-documentation-field

    > If no URL is specified in the manifest file, crates.io will automatically link your crate to the corresponding docs.rs page.


