### PR TITLE
Fix a mini memory leak in Bytes on a racy promotion from vec to arc

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1044,7 +1044,10 @@ unsafe fn shallow_clone_vec(
             // the allocation that was made in this thread, it will not
             // be needed.
             let shared = Box::from_raw(shared);
-            mem::forget(*shared);
+            // But don't drop `_vec` as it used by the concurrent clone.
+            // Note: the partial move works here because `Shared` doesn't
+            // implement `Drop`.
+            mem::forget(shared._vec);
 
             // Buffer already promoted to shared storage, so increment ref
             // count.


### PR DESCRIPTION
Hi,
I was looking around trying to understand the implementation of `Bytes` when I found something that puzzled me in `fn shallow_clone_vec(...)`
https://github.com/tokio-rs/bytes/blob/ed1d24e57079a86c6201b5fd6be6f789265f0e6a/src/bytes.rs#L1042-L1047
It seems that this code create a memory leak (`ref_cnt: AtomicUsize::new(2)` is not deleted).
Or maybe I missed something,  in this case maybe a more explicit comment may be welcomed.

I created a PR to fix this leak.
This this just to make this code more correct - because this leak is tiny add should be rare (only when the promotion from `arc` to `vec` is performed by several threads at the same time)