### PR TITLE
Keep capacity when unsplit on empty other buf

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -819,7 +819,7 @@ impl BytesMut {
     }
 
     fn try_unsplit(&mut self, other: BytesMut) -> Result<(), BytesMut> {
-        if other.is_empty() {
+        if other.capacity() == 0 {
             return Ok(());
         }
 

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -785,6 +785,31 @@ fn bytes_mut_unsplit_empty_self() {
 }
 
 #[test]
+fn bytes_mut_unsplit_other_keeps_capacity() {
+    let mut buf = BytesMut::with_capacity(64);
+    buf.extend_from_slice(b"aabb");
+
+    // non empty other created "from" buf
+    let mut other = buf.split_off(buf.len());
+    other.extend_from_slice(b"ccddee");
+    buf.unsplit(other);
+
+    assert_eq!(buf.capacity(), 64);
+}
+
+#[test]
+fn bytes_mut_unsplit_empty_other_keeps_capacity() {
+    let mut buf = BytesMut::with_capacity(64);
+    buf.extend_from_slice(b"aabbccddee");
+
+    // empty other created "from" buf
+    let other = buf.split_off(buf.len());
+    buf.unsplit(other);
+
+    assert_eq!(buf.capacity(), 64);
+}
+
+#[test]
 fn bytes_mut_unsplit_arc_different() {
     let mut buf = BytesMut::with_capacity(64);
     buf.extend_from_slice(b"aaaabbbbeeee");


### PR DESCRIPTION
When trying to `unsplit()` from a previous `split()`:

- if the `other` buf is not empty the `unsplit()` results in a buf with the initial capacity
- if the `other` buf is empty, other is dropped, capacity lost, and anything new added to the initial buf leads to a reallocation

This changes this second behavior so that even if `other` is empty the overall capacity is kept.