### PR TITLE
Clarifying actions of clear and truncate.

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -380,6 +380,8 @@ impl BytesMut {
     /// If `len` is greater than the buffer's current length, this has no
     /// effect.
     ///
+    /// Existing underlying capacity is preserved.
+    ///
     /// The [`split_off`] method can emulate `truncate`, but this causes the
     /// excess bytes to be returned instead of dropped.
     ///
@@ -402,7 +404,7 @@ impl BytesMut {
         }
     }
 
-    /// Clears the buffer, removing all data.
+    /// Clears the buffer, removing all data. Existing capacity is preserved.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
I have added to the documentation on the clear and truncate functions to note that the capacity should be unaffected when they are called.

If my reading of the code is incorrect please reject this commit.