### PR TITLE
Prepare bytes v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 1.1.0 (August 25, 2021)
+
+### Added
+
+- `BufMut::put_bytes(self, val, cnt)` (#487)
+- Implement `From<Box<[u8]>>` for `Bytes` (#504)
+
+### Changed
+
+- Override `put_slice` for `&mut [u8]` (#483)
+- Panic on integer overflow in `Chain::remaining` (#482)
+- Add inline tags to `UninitSlice` methods (#443)
+- Override `copy_to_bytes` for Chain and Take (#481)
+- Keep capacity when unsplit on empty other buf (#502)
+
+### Documented
+
+- Clarify `BufMut` allocation guarantees (#501)
+- Clarify `BufMut::put_int` behavior (#486)
+- Clarify actions of `clear` and `truncate`. (#508)
+
 # 1.0.1 (January 11, 2021)
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bytes"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create "v1.0.x" git tag.
-version = "1.0.1"
+version = "1.1.0"
 license = "MIT"
 authors = [
     "Carl Lerche <me@carllerche.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "bytes"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
-# - Create "v1.0.x" git tag.
+# - Create "v1.x.y" git tag.
 version = "1.1.0"
 license = "MIT"
 authors = [


### PR DESCRIPTION
# 1.1.0 (August 25, 2021)

### Added

- `BufMut::put_bytes(self, val, cnt)` ([#487])
- Implement `From<Box<[u8]>>` for `Bytes` ([#504])

### Changed

- Override `put_slice` for `&mut [u8]` ([#483])
- Panic on integer overflow in `Chain::remaining` ([#482])
- Add inline tags to `UninitSlice` methods ([#443])
- Override `copy_to_bytes` for Chain and Take ([#481])
- Keep capacity when unsplit on empty other buf ([#502])

### Documented

- Clarify `BufMut` allocation guarantees ([#501])
- Clarify `BufMut::put_int` behavior ([#486])
- Clarify actions of `clear` and `truncate`. ([#508])

[#443]: https://github.com/tokio-rs/bytes/issues/443
[#481]: https://github.com/tokio-rs/bytes/issues/481
[#482]: https://github.com/tokio-rs/bytes/issues/482
[#483]: https://github.com/tokio-rs/bytes/issues/483
[#486]: https://github.com/tokio-rs/bytes/issues/486
[#487]: https://github.com/tokio-rs/bytes/issues/487
[#501]: https://github.com/tokio-rs/bytes/issues/501
[#502]: https://github.com/tokio-rs/bytes/issues/502
[#504]: https://github.com/tokio-rs/bytes/issues/504
[#508]: https://github.com/tokio-rs/bytes/issues/508