### PR TITLE
Changed the Buf/BufMut implementations to accept isize/usize

### DIFF
--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -650,8 +650,8 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_uint(&mut self, nbytes: usize) -> u64 {
-        buf_get_impl!(be => self, u64, nbytes);
+    fn get_uint(&mut self, nbytes: usize) -> usize {
+        buf_get_impl!(be => self, usize, nbytes);
     }
 
     /// Gets an unsigned n-byte integer from `self` in little-endian byte order.
@@ -670,8 +670,8 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_uint_le(&mut self, nbytes: usize) -> u64 {
-        buf_get_impl!(le => self, u64, nbytes);
+    fn get_uint_le(&mut self, nbytes: usize) -> usize {
+        buf_get_impl!(le => self, usize, nbytes);
     }
 
     /// Gets a signed n-byte integer from `self` in big-endian byte order.
@@ -690,8 +690,8 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_int(&mut self, nbytes: usize) -> i64 {
-        buf_get_impl!(be => self, i64, nbytes);
+    fn get_int(&mut self, nbytes: usize) -> isize {
+        buf_get_impl!(be => self, isize, nbytes);
     }
 
     /// Gets a signed n-byte integer from `self` in little-endian byte order.
@@ -710,8 +710,8 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_int_le(&mut self, nbytes: usize) -> i64 {
-        buf_get_impl!(le => self, i64, nbytes);
+    fn get_int_le(&mut self, nbytes: usize) -> isize {
+        buf_get_impl!(le => self, isize, nbytes);
     }
 
     /// Gets an IEEE754 single-precision (4 bytes) floating point number from
@@ -988,19 +988,19 @@ macro_rules! deref_forward_buf {
             (**self).get_i64_le()
         }
 
-        fn get_uint(&mut self, nbytes: usize) -> u64 {
+        fn get_uint(&mut self, nbytes: usize) -> usize {
             (**self).get_uint(nbytes)
         }
 
-        fn get_uint_le(&mut self, nbytes: usize) -> u64 {
+        fn get_uint_le(&mut self, nbytes: usize) -> usize {
             (**self).get_uint_le(nbytes)
         }
 
-        fn get_int(&mut self, nbytes: usize) -> i64 {
+        fn get_int(&mut self, nbytes: usize) -> isize {
             (**self).get_int(nbytes)
         }
 
-        fn get_int_le(&mut self, nbytes: usize) -> i64 {
+        fn get_int_le(&mut self, nbytes: usize) -> isize {
             (**self).get_int_le(nbytes)
         }
 

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -708,7 +708,7 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_uint(&mut self, n: u64, nbytes: usize) {
+    fn put_uint(&mut self, n: usize, nbytes: usize) {
         self.put_slice(&n.to_be_bytes()[mem::size_of_val(&n) - nbytes..]);
     }
 
@@ -730,7 +730,7 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_uint_le(&mut self, n: u64, nbytes: usize) {
+    fn put_uint_le(&mut self, n: usize, nbytes: usize) {
         self.put_slice(&n.to_le_bytes()[0..nbytes]);
     }
 
@@ -752,7 +752,7 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self` or if `nbytes` is greater than 8.
-    fn put_int(&mut self, n: i64, nbytes: usize) {
+    fn put_int(&mut self, n: isize, nbytes: usize) {
         self.put_slice(&n.to_be_bytes()[mem::size_of_val(&n) - nbytes..]);
     }
 
@@ -774,7 +774,7 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self` or if `nbytes` is greater than 8.
-    fn put_int_le(&mut self, n: i64, nbytes: usize) {
+    fn put_int_le(&mut self, n: isize, nbytes: usize) {
         self.put_slice(&n.to_le_bytes()[0..nbytes]);
     }
 


### PR DESCRIPTION
Currently if you call But::get_uint_le it returns a u64 no matter what platform you are running on.

I have changed it and associated functions to directly accept and return isize/usize.

**Note:** This is a method signature changing function so I wasn't sure how far I should go. What that means is that it still accepts a byte count as an argument. I think it would be better to remove that argument but that will be a much bigger breaking change.

Depending on feedback to this pull request, I'll happily make changes to accomplish that as well (and I think it's the right thing to do).