### PR TITLE
Implemented usize/isize as new functions on the Buf/BufMut traits

### DIFF
--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -674,6 +674,28 @@ pub trait Buf {
         buf_get_impl!(le => self, u64, nbytes);
     }
 
+    /// Gets an unsigned usize byte integer from `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by `size_of::<usize>()`.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_usize(&mut self) -> usize {
+        buf_get_impl!(self, usize::from_be_bytes);
+    }
+
+    /// Gets an unsigned usize byte integer from `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by `size_of::<usize>()`.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_usize_le(&mut self) -> usize {
+        buf_get_impl!(self, usize::from_le_bytes);
+    }
+
     /// Gets a signed n-byte integer from `self` in big-endian byte order.
     ///
     /// The current position is advanced by `nbytes`.
@@ -712,6 +734,28 @@ pub trait Buf {
     /// This function panics if there is not enough remaining data in `self`.
     fn get_int_le(&mut self, nbytes: usize) -> i64 {
         buf_get_impl!(le => self, i64, nbytes);
+    }
+
+    /// Gets a signed isize byte integer from `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by `size_of::<isize>()`.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_isize(&mut self) -> isize {
+        buf_get_impl!(self, isize::from_be_bytes);
+    }
+
+    /// Gets a signed isize byte integer from `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by `size_of::<isize>()`.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_isize_le(&mut self) -> isize {
+        buf_get_impl!(self, isize::from_le_bytes);
     }
 
     /// Gets an IEEE754 single-precision (4 bytes) floating point number from

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -734,6 +734,32 @@ pub unsafe trait BufMut {
         self.put_slice(&n.to_le_bytes()[0..nbytes]);
     }
 
+    /// Writes an unsigned usize integer to `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by `size_of::<usize>()`.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_usize(&mut self, n: usize) {
+        self.put_slice(&n.to_be_bytes());
+    }
+
+    /// Writes an unsigned usize integer to `self` in the little-endian byte order.
+    ///
+    /// The current position is advanced by `size_of::<usize>()`.
+    ///
+    /// # Examples
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_usize_le(&mut self, n: usize) {
+        self.put_slice(&n.to_le_bytes());
+    }
+
     /// Writes low `nbytes` of a signed integer to `self` in big-endian byte order.
     ///
     /// The current position is advanced by `nbytes`.
@@ -776,6 +802,32 @@ pub unsafe trait BufMut {
     /// `self` or if `nbytes` is greater than 8.
     fn put_int_le(&mut self, n: i64, nbytes: usize) {
         self.put_slice(&n.to_le_bytes()[0..nbytes]);
+    }
+
+    /// Writes a signed isize integer to `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by `size_of::<isize>()`.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_isize(&mut self, n: isize) {
+        self.put_slice(&n.to_be_bytes());
+    }
+
+    /// Writes a signed isize integer to `self` in the little-endian byte order.
+    ///
+    /// The current position is advanced by `size_of::<isize>()`.
+    ///
+    /// # Examples
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_isize_le(&mut self, n: isize) {
+        self.put_slice(&n.to_le_bytes());
     }
 
     /// Writes  an IEEE754 single-precision (4 bytes) floating point number to

--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -43,6 +43,30 @@ fn test_get_u16_buffer_underflow() {
     buf.get_u16();
 }
 
+#[test]
+fn test_get_isize() {
+    let mut buf = &isize::MAX.to_be_bytes()[..];
+    assert_eq!(isize::MAX, buf.get_isize());
+}
+
+#[test]
+fn test_get_isize_le() {
+    let mut buf = &isize::MIN.to_le_bytes()[..];
+    assert_eq!(isize::MIN, buf.get_isize_le());
+}
+
+#[test]
+fn test_get_usize() {
+    let mut buf = &usize::MAX.to_be_bytes()[..];
+    assert_eq!(usize::MAX, buf.get_usize());
+}
+
+#[test]
+fn test_get_usize_le() {
+    let mut buf = &usize::MIN.to_le_bytes()[..];
+    assert_eq!(usize::MIN, buf.get_usize_le());
+}
+
 #[cfg(feature = "std")]
 #[test]
 fn test_bufs_vec() {

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -4,6 +4,7 @@ use bytes::buf::UninitSlice;
 use bytes::{BufMut, BytesMut};
 use core::fmt::Write;
 use core::usize;
+use std::mem::size_of;
 
 #[test]
 fn test_vec_as_mut_buf() {
@@ -79,6 +80,34 @@ fn test_put_int_le() {
 fn test_put_int_le_nbytes_overflow() {
     let mut buf = Vec::with_capacity(8);
     buf.put_int_le(0x1020304050607080, 9);
+}
+
+#[test]
+fn test_put_isize() {
+    let mut buf = Vec::with_capacity(size_of::<isize>());
+    buf.put_isize(isize::MAX);
+    assert_eq!(isize::MAX.to_be_bytes(), &buf[..]);
+}
+
+#[test]
+fn test_put_isize_le() {
+    let mut buf = Vec::with_capacity(size_of::<isize>());
+    buf.put_isize_le(isize::MIN);
+    assert_eq!(isize::MIN.to_le_bytes(), &buf[..]);
+}
+
+#[test]
+fn test_put_usize() {
+    let mut buf = Vec::with_capacity(size_of::<usize>());
+    buf.put_usize(usize::MAX);
+    assert_eq!(usize::MAX.to_be_bytes(), &buf[..]);
+}
+
+#[test]
+fn test_put_usize_le() {
+    let mut buf = Vec::with_capacity(size_of::<usize>());
+    buf.put_usize_le(usize::MIN);
+    assert_eq!(usize::MIN.to_le_bytes(), &buf[..]);
 }
 
 #[test]


### PR DESCRIPTION
I needed an easier way to handle reading and writing architecture specific sizes so I have implemented the additional functions.

I couldn't think of good architecture specific examples unless the unit tests I added would make better sense there.