### PR TITLE
Appease miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  nightly: nightly-2021-04-13
+  nightly: nightly-2021-11-1
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  nightly: nightly-2021-11-1
+  nightly: nightly-2021-11-5
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  nightly: nightly
+  nightly: nightly-2021-11-05
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  nightly: nightly-2021-11-5
+  nightly: nightly
 
 defaults:
   run:

--- a/tests/test_bytes_vec_alloc.rs
+++ b/tests/test_bytes_vec_alloc.rs
@@ -43,7 +43,12 @@ impl Ledger {
             //
             // dont worry, LEDGER_LENGTH is really long to compensate for us not reclaiming space
             if entry_ptr
-                .compare_exchange(ptr, usize::MAX as *mut u8, Ordering::SeqCst, Ordering::SeqCst)
+                .compare_exchange(
+                    ptr,
+                    usize::MAX as *mut u8,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                )
                 .is_ok()
             {
                 return entry_size.load(Ordering::Relaxed);

--- a/tests/test_bytes_vec_alloc.rs
+++ b/tests/test_bytes_vec_alloc.rs
@@ -47,7 +47,10 @@ impl Ledger {
 
     fn remove(&self, ptr: *mut u8) -> usize {
         for (entry_ptr, entry_size) in self.alloc_table.iter() {
-            if entry_ptr.compare_exchange(ptr, null_mut(), Ordering::SeqCst, Ordering::SeqCst).is_ok() {
+            if entry_ptr
+                .compare_exchange(ptr, null_mut(), Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
                 return entry_size.swap(0, Ordering::Relaxed);
             }
         }

--- a/tests/test_bytes_vec_alloc.rs
+++ b/tests/test_bytes_vec_alloc.rs
@@ -51,7 +51,7 @@ impl Ledger {
                 )
                 .is_ok()
             {
-                return entry_size.load(Ordering::Relaxed);
+                return entry_size.load(Ordering::SeqCst);
             }
         }
 

--- a/tests/test_bytes_vec_alloc.rs
+++ b/tests/test_bytes_vec_alloc.rs
@@ -1,5 +1,5 @@
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::{mem};
+use std::mem;
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 
@@ -17,10 +17,10 @@ impl Ledger {
     const fn new() -> Self {
         // equivalent to size of (AtomicPtr<u8>, AtomicUsize), hopefully
         #[cfg(target_pointer_width = "64")]
-            let tricky_bits = 0u128;
+        let tricky_bits = 0u128;
 
         #[cfg(target_pointer_width = "32")]
-            let tricky_bits = 0u64;
+        let tricky_bits = 0u64;
 
         let magic_table = [tricky_bits; 512];
 
@@ -35,12 +35,9 @@ impl Ledger {
     fn insert(&self, ptr: *mut u8, size: usize) {
         for (entry_ptr, entry_size) in self.alloc_table.iter() {
             // SeqCst is good enough here, we don't care about perf, i just want to be correct!
-            if entry_ptr.compare_exchange(
-                null_mut(),
-                ptr,
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            ).is_ok()
+            if entry_ptr
+                .compare_exchange(null_mut(), ptr, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
             {
                 entry_size.store(size, Ordering::Relaxed);
                 break;


### PR DESCRIPTION
Rewrote the ledger in `test_bytes_vec_alloc.rs` to not piss off miri. The ledger is now a table within the allocator, which seems to satisfy miri. The old solution was to bundle an extra usize into the beginning of each allocation and then index past the start when deallocating data to get the size.

~There is one janky bit here with a transmute, but there isn't a better way to initialize an array with zeroed data in a const context that I am aware of sadly.~ Thanks to @paolobarbolini for finding a better way to do this!