### PR TITLE
Implement `Extend<Bytes>` for `BytesMut`

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1211,6 +1211,17 @@ impl<'a> Extend<&'a u8> for BytesMut {
     }
 }
 
+impl Extend<Bytes> for BytesMut {
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = Bytes>,
+    {
+        for bytes in iter {
+            self.extend_from_slice(&bytes)
+        }
+    }
+}
+
 impl FromIterator<u8> for BytesMut {
     fn from_iter<T: IntoIterator<Item = u8>>(into_iter: T) -> Self {
         BytesMut::from_vec(Vec::from_iter(into_iter))

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -545,6 +545,13 @@ fn extend_from_slice_mut() {
 }
 
 #[test]
+fn extend_mut_from_bytes() {
+    let mut bytes = BytesMut::with_capacity(0);
+    bytes.extend([Bytes::from(LONG)]);
+    assert_eq!(*bytes, LONG[..]);
+}
+
+#[test]
 fn extend_mut_without_size_hint() {
     let mut bytes = BytesMut::with_capacity(0);
     let mut long_iter = LONG.iter();


### PR DESCRIPTION
## Motivation
This lets us play nice `Stream`'s [methods](https://docs.rs/futures-util/0.3.19/futures_util/stream/trait.StreamExt.html#method.collect) like:

```rust
fn get_stream() -> impl Stream<Item = Bytes> { todo!() };
let payload = get_stream().collect::<BytesMut>().await;
```

```rust
fn get_stream() -> impl Stream<Item = Result<Bytes, E>> { todo!() };
let payload = get_stream().try_collect::<BytesMut>().await?;
```

Since the bound on this `collect` is a bit different to std's iter `collect` which is based on `FromIterator`.