### PR TITLE
Fix bugs in `BytesMut::reserve_inner`

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -646,7 +646,7 @@ impl BytesMut {
                     self.cap = v.capacity();
                 } else {
                     // calculate offset
-                    let off = v.capacity() - self.cap;
+                    let off = (self.ptr.as_ptr() as usize) - (v.as_ptr() as usize);
 
                     // new_cap is calculated in terms of `BytesMut`, not the underlying
                     // `Vec`, so it does not take the offset into account.

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -2,7 +2,6 @@
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-use std::mem;
 use std::usize;
 
 const LONG: &[u8] = b"mary had a little lamb, little lamb, little lamb";
@@ -535,11 +534,11 @@ fn reserve_in_arc_nonunique_does_not_overallocate() {
 fn reserve_shared_reuse() {
     let mut bytes = BytesMut::with_capacity(1000);
     bytes.put_slice(b"Hello, World!");
-    mem::forget(bytes.split());
+    drop(bytes.split());
 
     bytes.put_slice(b"!123ex123,sadchELLO,_wORLD!");
     // Use split_off so that v.capacity() - self.cap != off
-    mem::forget(bytes.split_off(9));
+    drop(bytes.split_off(9));
     assert_eq!(&*bytes, b"!123ex123");
 
     bytes.reserve(2000);


### PR DESCRIPTION
Fixed bugs introduced in #529 , `BytesMut::reserve_inner`:
 -  Fix calculation of offset

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>