### PR TITLE
miri: don't use int2ptr casts for invalid pointers

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1556,7 +1556,7 @@ fn vptr(ptr: *mut u8) -> NonNull<u8> {
 /// provenance checking is enabled.
 #[inline]
 fn invalid_ptr<T>(addr: usize) -> *mut T {
-    let ptr = std::ptr::null_mut::<u8>().wrapping_add(addr);
+    let ptr = core::ptr::null_mut::<u8>().wrapping_add(addr);
     debug_assert_eq!(ptr as usize, addr);
     ptr.cast::<T>()
 }

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1551,19 +1551,14 @@ fn vptr(ptr: *mut u8) -> NonNull<u8> {
 
 /// Returns a dangling pointer with the given address. This is used to store
 /// integer data in pointer fields.
+///
+/// It is equivalent to `addr as *mut T`, but this fails on miri when strict
+/// provenance checking is enabled.
 #[inline]
 fn invalid_ptr<T>(addr: usize) -> *mut T {
-    #[cfg(miri)]
-    {
-        let ptr = std::ptr::null_mut::<u8>().wrapping_add(addr);
-        assert_eq!(ptr as usize, addr);
-        ptr.cast::<T>()
-    }
-
-    #[cfg(not(miri))]
-    {
-        addr as *mut T
-    }
+    let ptr = std::ptr::null_mut::<u8>().wrapping_add(addr);
+    debug_assert_eq!(ptr as usize, addr);
+    ptr.cast::<T>()
 }
 
 unsafe fn rebuild_vec(ptr: *mut u8, mut len: usize, mut cap: usize, off: usize) -> Vec<u8> {

--- a/tests/test_bytes_vec_alloc.rs
+++ b/tests/test_bytes_vec_alloc.rs
@@ -108,15 +108,7 @@ fn test_bytes_truncate_and_advance() {
 /// integer data in pointer fields.
 #[inline]
 fn invalid_ptr<T>(addr: usize) -> *mut T {
-    #[cfg(miri)]
-    {
-        let ptr = std::ptr::null_mut::<u8>().wrapping_add(addr);
-        assert_eq!(ptr as usize, addr);
-        ptr.cast::<T>()
-    }
-
-    #[cfg(not(miri))]
-    {
-        addr as *mut T
-    }
+    let ptr = std::ptr::null_mut::<u8>().wrapping_add(addr);
+    debug_assert_eq!(ptr as usize, addr);
+    ptr.cast::<T>()
 }


### PR DESCRIPTION
This fixes a miri failure with strict provenance.