### PR TITLE
Fix: `From<BytesMut> fo Vec<u8>` implementation

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1550,9 +1550,10 @@ impl From<BytesMut> for Vec<u8> {
                 rebuild_vec(bytes.ptr.as_ptr(), bytes.len, bytes.cap, off)
             }
         } else if kind == KIND_ARC {
-            let shared = unsafe { &mut *(bytes.data as *mut Shared) };
-            if shared.is_unique() {
-                let vec = mem::replace(&mut shared.vec, Vec::new());
+            let shared = bytes.data as *mut Shared;
+
+            if unsafe { (*shared).is_unique() } {
+                let vec = mem::replace(unsafe { &mut (*shared).vec }, Vec::new());
 
                 unsafe { release_shared(shared) };
 

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1553,7 +1553,7 @@ impl From<BytesMut> for Vec<u8> {
             let shared = bytes.data as *mut Shared;
 
             if unsafe { (*shared).is_unique() } {
-                let vec = mem::take(unsafe { &mut (*shared).vec });
+                let vec = mem::replace(unsafe { &mut (*shared).vec }, Vec::new());
 
                 unsafe { release_shared(shared) };
 

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1553,7 +1553,7 @@ impl From<BytesMut> for Vec<u8> {
             let shared = bytes.data as *mut Shared;
 
             if unsafe { (*shared).is_unique() } {
-                let vec = mem::replace(unsafe { &mut (*shared).vec }, Vec::new());
+                let vec = mem::take(unsafe { &mut (*shared).vec });
 
                 unsafe { release_shared(shared) };
 

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1559,10 +1559,10 @@ impl From<BytesMut> for Vec<u8> {
 
                 vec
             } else {
-                return bytes.deref().into();
+                return bytes.deref().to_vec();
             }
         } else {
-            return bytes.deref().into();
+            return bytes.deref().to_vec();
         };
 
         let len = bytes.len;


### PR DESCRIPTION
Avoid creating `&mut Shared` until `Shared::is_unique` returns `true`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>