### PR TITLE
chore: prepare bytes v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# 1.2.0 (July 19, 2022)
+
+### Added
+
+- Add `BytesMut::zeroed` (#517)
+- Implement `Extend<Bytes>` for `BytesMut` (#527)
+- Add conversion from `BytesMut` to `Vec<u8>` (#543, #554)
+- Add conversion from `Bytes` to `Vec<u8>` (#547)
+- Add `UninitSlice::as_uninit_slice_mut()` (#548)
+- Add const to `Bytes::{len,is_empty}` (#514)
+
+### Changed
+
+- Reuse vector in `BytesMut::reserve` (#539, #544)
+
+### Fixed
+
+- Make miri happy (#515, #523, #542, #545, #553)
+- Make tsan happy (#541)
+- Fix `remaining_mut()` on chain (#488)
+- Fix amortized asymptotics of `BytesMut` (#555)
+
+### Documented
+
+- Redraw layout diagram with box drawing characters (#539)
+- Clarify `BytesMut::unsplit` docs (#535)
+
 # 1.1.0 (August 25, 2021)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bytes"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.1.0"
+version = "1.2.0"
 license = "MIT"
 authors = [
     "Carl Lerche <me@carllerche.com>",


### PR DESCRIPTION
# 1.2.0 (July 19, 2022)

### Added

- Add `BytesMut::zeroed` ([#517])
- Implement `Extend<Bytes>` for `BytesMut` ([#527])
- Add conversion from `BytesMut` to `Vec<u8>` ([#543], [#554])
- Add conversion from `Bytes` to `Vec<u8>` ([#547])
- Add `UninitSlice::as_uninit_slice_mut()` ([#548])
- Add const to `Bytes::{len,is_empty}` ([#514])

### Changed

- Reuse vector in `BytesMut::reserve` ([#539], [#544])

### Fixed

- Make miri happy ([#515], [#523], [#542], [#545], [#553])
- Make tsan happy ([#541])
- Fix `remaining_mut()` on chain ([#488])
- Fix amortized asymptotics of `BytesMut` ([#555])

### Documented

- Redraw layout diagram with box drawing characters ([#539])
- Clarify `BytesMut::unsplit` docs ([#535])

[#488]: https://github.com/tokio-rs/bytes/pull/488
[#514]: https://github.com/tokio-rs/bytes/pull/514
[#515]: https://github.com/tokio-rs/bytes/pull/515
[#517]: https://github.com/tokio-rs/bytes/pull/517
[#523]: https://github.com/tokio-rs/bytes/pull/523
[#527]: https://github.com/tokio-rs/bytes/pull/527
[#535]: https://github.com/tokio-rs/bytes/pull/535
[#539]: https://github.com/tokio-rs/bytes/pull/539
[#539]: https://github.com/tokio-rs/bytes/pull/539
[#541]: https://github.com/tokio-rs/bytes/pull/541
[#542]: https://github.com/tokio-rs/bytes/pull/542
[#543]: https://github.com/tokio-rs/bytes/pull/543
[#544]: https://github.com/tokio-rs/bytes/pull/544
[#545]: https://github.com/tokio-rs/bytes/pull/545
[#547]: https://github.com/tokio-rs/bytes/pull/547
[#548]: https://github.com/tokio-rs/bytes/pull/548
[#553]: https://github.com/tokio-rs/bytes/pull/553
[#554]: https://github.com/tokio-rs/bytes/pull/554
[#555]: https://github.com/tokio-rs/bytes/pull/555
