### PR TITLE
Stabilize vtable api

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -105,7 +105,8 @@ pub struct Bytes {
     vtable: &'static Vtable,
 }
 
-pub(crate) struct Vtable {
+/// Raw methods for managing memory inside byte
+pub struct Vtable {
     /// fn(data, ptr, len)
     pub clone: unsafe fn(&AtomicPtr<()>, *const u8, usize) -> Bytes,
     /// fn(data, ptr, len)
@@ -484,8 +485,14 @@ impl Bytes {
         self.truncate(0);
     }
 
+    // Creates a new `Bytes` from a raw pointer and a vtable.
+    ///
+    /// The returned `Bytes` will point directly to the given memory. There is
+    /// no allocating or copying.
+    /// # Safety
+    /// Unsafe because methods in vtable are unsafe
     #[inline]
-    pub(crate) unsafe fn with_vtable(
+    pub unsafe fn with_vtable(
         ptr: *const u8,
         len: usize,
         data: AtomicPtr<()>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ mod bytes;
 mod bytes_mut;
 mod fmt;
 mod loom;
-pub use crate::bytes::Bytes;
+pub use crate::bytes::{Bytes, Vtable};
 pub use crate::bytes_mut::BytesMut;
 
 // Optional Serde support


### PR DESCRIPTION
The use case is for example use Bytes create with memory from mmap.
A file is mapped in memory before construct of the first bytes, and unmapped when the last is dropped.