### PR TITLE
Fix reserve over allocating underlying buffer

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -670,7 +670,10 @@ impl BytesMut {
 
                 // Compare the condition in the `kind == KIND_VEC` case above
                 // for more details.
-                if v_capacity >= new_cap && offset >= len {
+                if v_capacity >= new_cap + offset {
+                    self.cap = new_cap;
+                    // no copy is necessary
+                } else if v_capacity >= new_cap && offset >= len {
                     // The capacity is sufficient, and copying is not too much
                     // overhead: reclaim the buffer!
 


### PR DESCRIPTION
Fixes calls to `reserve` when the underlying shared buffer was already
big enough to fit the requested capacity. Previously a new even larger
buffer was created anyways. This could eventually lead to an OOM
condition.

Fixes #559 