### PR TITLE
chore: prepare bytes v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.1 (July 30, 2022)
+
+### Fixed
+
+- Fix unbounded memory growth when using `reserve` (#560)
+
 # 1.2.0 (July 19, 2022)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bytes"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.2.0"
+version = "1.2.1"
 license = "MIT"
 authors = [
     "Carl Lerche <me@carllerche.com>",


### PR DESCRIPTION
# 1.2.1 (July 30, 2022)

### Fixed

- Fix unbounded memory growth when using `reserve` ([#560])

[#560]: https://github.com/tokio-rs/bytes/pull/560