### PR TITLE
Support `atomic-polyfill` for targets without native atomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,11 @@ edition = "2018"
 [features]
 default = ["std"]
 std = []
+atomic-polyfill = ["dep:atomic-polyfill"]
 
 [dependencies]
 serde = { version = "1.0.60", optional = true, default-features = false, features = ["alloc"] }
+atomic-polyfill = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 [features]
 default = ["std"]
 std = []
-atomic-polyfill = ["dep:atomic-polyfill"]
+use-atomic-polyfill = ["atomic-polyfill"]
 
 [dependencies]
 serde = { version = "1.0.60", optional = true, default-features = false, features = ["alloc"] }

--- a/src/loom.rs
+++ b/src/loom.rs
@@ -1,7 +1,11 @@
 #[cfg(not(all(test, loom)))]
 pub(crate) mod sync {
     pub(crate) mod atomic {
+        #[cfg(not(feature = "atomic-polyfill"))]
         pub(crate) use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+
+        #[cfg(feature = "atomic-polyfill")]
+        pub(crate) use atomic_polyfill::{AtomicPtr, AtomicUsize, Ordering};
 
         pub(crate) trait AtomicMut<T> {
             fn with_mut<F, R>(&mut self, f: F) -> R

--- a/src/loom.rs
+++ b/src/loom.rs
@@ -1,10 +1,10 @@
 #[cfg(not(all(test, loom)))]
 pub(crate) mod sync {
     pub(crate) mod atomic {
-        #[cfg(not(feature = "atomic-polyfill"))]
+        #[cfg(not(feature = "use-atomic-polyfill"))]
         pub(crate) use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 
-        #[cfg(feature = "atomic-polyfill")]
+        #[cfg(feature = "use-atomic-polyfill")]
         pub(crate) use atomic_polyfill::{AtomicPtr, AtomicUsize, Ordering};
 
         pub(crate) trait AtomicMut<T> {


### PR DESCRIPTION
Hi!

It's awesome that this crate is `no-std` (it's actually being used in some firmware!) -- but we've found that when compiling for architectures without native atomics support such as `thumbv6m-none-eabi` (i.e., Cortex-M0 such as in the Atmel ATSAMD21 and Raspberry Pi RP2040), well, we can't compile...

While the `core::sync::atomic` modules/types exist in those targets, they don't actually support compare_exchange/fetch_add/fetch_sub as are used by this crate.

The awesome folks working on [Embassy](https://github.com/embassy-rs) actually have an [`atomic-polyfill`](https://github.com/embassy-rs/atomic-polyfill) crate for this exact scenario, this PR adds a feature gate to use it, allowing one to build this crate for even more `no-std` targets.