### PR TITLE
Update CI toolchain to a recent nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  nightly: nightly-2021-11-05
+  nightly: nightly-2022-11-12
 
 defaults:
   run:


### PR DESCRIPTION
Currently, the loom test fails to compile some of its dependencies because the toolchain is too old. This updates the toolchain to yesterday's nightly so that CI passes.