### PR TITLE
make IntoIter constructor public

### DIFF
--- a/src/buf/iter.rs
+++ b/src/buf/iter.rs
@@ -2,8 +2,6 @@ use crate::Buf;
 
 /// Iterator over the bytes contained by the buffer.
 ///
-/// This struct is created by the [`iter`] method on [`Buf`].
-///
 /// # Examples
 ///
 /// Basic usage:
@@ -43,7 +41,7 @@ impl<T> IntoIter<T> {
     /// assert_eq!(iter.next(), Some(b'c'));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub(crate) fn new(inner: T) -> IntoIter<T> {
+    pub fn new(inner: T) -> IntoIter<T> {
         IntoIter { inner }
     }
 


### PR DESCRIPTION
This PR makes the constructor of `IntoIter` public, so that it can be used with arbitrary Buf implementations.

Fixes #580.