### PR TITLE
Document which `Buf` and `BufMut` functions require `std`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
-        run: rustup update nightly && rustup default nightly
+        run: rustup update $nightly && rustup default $nightly
       - name: Build documentation
         run: cargo doc --no-deps --all-features
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
-        run: rustup update stable && rustup default stable
+        run: rustup update nightly && rustup default nightly
       - name: Build documentation
         run: cargo doc --no-deps --all-features
         env:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Serde support is optional and disabled by default. To enable use the feature `se
 bytes = { version = "1", features = ["serde"] }
 ```
 
+## Building documentation
+
+When building the `bytes` documentation the `docsrs` option should be used, otherwise
+feature gates will not be shown. This requires a nightly toolchain:
+
+```
+RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc
+```
+
 ## License
 
 This project is licensed under the [MIT license](LICENSE).

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -160,6 +160,7 @@ pub trait Buf {
     ///
     /// [`writev`]: http://man7.org/linux/man-pages/man2/readv.2.html
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn chunks_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
         if dst.is_empty() {
             return 0;
@@ -1183,6 +1184,7 @@ pub trait Buf {
     /// assert_eq!(&dst[..11], &b"hello world"[..]);
     /// ```
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn reader(self) -> Reader<Self>
     where
         Self: Sized,

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -1239,6 +1239,7 @@ pub unsafe trait BufMut {
     /// assert_eq!(*buf, b"hello world"[..]);
     /// ```
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn writer(self) -> Writer<Self>
     where
         Self: Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Provides abstractions for working with bytes.
 //!


### PR DESCRIPTION
Marks `Buf` and `BufMut` functions that depend on `std` as so.