### PR TITLE
Mark BytesMut::extend_from_slice as inline (#1)

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -761,6 +761,7 @@ impl BytesMut {
     ///
     /// assert_eq!(b"aaabbbcccddd", &buf[..]);
     /// ```
+    #[inline]
     pub fn extend_from_slice(&mut self, extend: &[u8]) {
         let cnt = extend.len();
         self.reserve(cnt);


### PR DESCRIPTION
* Mark BytesMut::extend_from_slice as inline

This function can be hot in applications that do a lot of encoding. Ideally would do the same for `<BytesMut as BufMut>::put_slice` and `<BytesMut as BufMut::put_u8`.


```sh
$ hyperfine ./target/release/benchber ./target/release/benchber.orig 
Benchmark 1: ./target/release/benchber
  Time (mean ± σ):      1.179 s ±  0.067 s    [User: 0.937 s, System: 0.226 s]
  Range (min … max):    1.055 s …  1.257 s    10 runs
 
Benchmark 2: ./target/release/benchber.orig
  Time (mean ± σ):      1.935 s ±  0.101 s    [User: 1.686 s, System: 0.233 s]
  Range (min … max):    1.795 s …  2.159 s    10 runs
 
Summary
  './target/release/benchber' ran
    1.64 ± 0.13 times faster than './target/release/benchber.orig'
```