### PR TITLE
feat: make alloc optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ edition = "2018"
 
 [features]
 default = ["std"]
-std = []
+std = ["alloc"]
+alloc = []
 
 [dependencies]
 serde = { version = "1.0.60", optional = true, default-features = false, features = ["alloc"] }

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -7,6 +7,7 @@ use core::{cmp, mem, ptr};
 #[cfg(feature = "std")]
 use std::io::IoSlice;
 
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 
 macro_rules! buf_get_impl {
@@ -1100,6 +1101,7 @@ pub trait Buf {
     /// let bytes = (&b"hello world"[..]).copy_to_bytes(5);
     /// assert_eq!(&bytes[..], &b"hello"[..]);
     /// ```
+    #[cfg(feature = "alloc")]
     fn copy_to_bytes(&mut self, len: usize) -> crate::Bytes {
         use super::BufMut;
 
@@ -1324,6 +1326,7 @@ macro_rules! deref_forward_buf {
             (**self).get_int_ne(nbytes)
         }
 
+        #[cfg(feature = "alloc")]
         fn copy_to_bytes(&mut self, len: usize) -> crate::Bytes {
             (**self).copy_to_bytes(len)
         }
@@ -1334,6 +1337,7 @@ impl<T: Buf + ?Sized> Buf for &mut T {
     deref_forward_buf!();
 }
 
+#[cfg(feature = "alloc")]
 impl<T: Buf + ?Sized> Buf for Box<T> {
     deref_forward_buf!();
 }

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -4,6 +4,7 @@ use crate::buf::{writer, Writer};
 
 use core::{cmp, mem, ptr, usize};
 
+#[cfg(feature = "alloc")]
 use alloc::{boxed::Box, vec::Vec};
 
 /// A trait for values that provide sequential write access to bytes.
@@ -1379,6 +1380,7 @@ unsafe impl<T: BufMut + ?Sized> BufMut for &mut T {
     deref_forward_bufmut!();
 }
 
+#[cfg(feature = "alloc")]
 unsafe impl<T: BufMut + ?Sized> BufMut for Box<T> {
     deref_forward_bufmut!();
 }
@@ -1454,6 +1456,7 @@ unsafe impl BufMut for &mut [core::mem::MaybeUninit<u8>] {
     }
 }
 
+#[cfg(feature = "alloc")]
 unsafe impl BufMut for Vec<u8> {
     #[inline]
     fn remaining_mut(&self) -> usize {

--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -1,5 +1,7 @@
 use crate::buf::{IntoIter, UninitSlice};
-use crate::{Buf, BufMut, Bytes};
+use crate::{Buf, BufMut};
+#[cfg(feature = "alloc")]
+use crate::Bytes;
 
 #[cfg(feature = "std")]
 use std::io::IoSlice;
@@ -171,6 +173,7 @@ where
         n
     }
 
+    #[cfg(feature = "alloc")]
     fn copy_to_bytes(&mut self, len: usize) -> Bytes {
         let a_rem = self.a.remaining();
         if a_rem >= len {

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -25,6 +25,7 @@ mod limit;
 mod reader;
 mod take;
 mod uninit_slice;
+#[cfg(feature = "alloc")]
 mod vec_deque;
 #[cfg(feature = "std")]
 mod writer;

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -1,4 +1,6 @@
-use crate::{Buf, Bytes};
+use crate::Buf;
+#[cfg(feature = "alloc")]
+use crate::Bytes;
 
 use core::cmp;
 
@@ -145,6 +147,7 @@ impl<T: Buf> Buf for Take<T> {
         self.limit -= cnt;
     }
 
+    #[cfg(feature = "alloc")]
     fn copy_to_bytes(&mut self, len: usize) -> Bytes {
         assert!(len <= self.remaining(), "`len` greater than remaining");
 

--- a/src/fmt/debug.rs
+++ b/src/fmt/debug.rs
@@ -1,6 +1,7 @@
 use core::fmt::{Debug, Formatter, Result};
 
 use super::BytesRef;
+#[cfg(feature = "alloc")]
 use crate::{Bytes, BytesMut};
 
 /// Alternative implementation of `std::fmt::Debug` for byte slice.
@@ -36,12 +37,14 @@ impl Debug for BytesRef<'_> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Debug for Bytes {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         Debug::fmt(&BytesRef(self.as_ref()), f)
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Debug for BytesMut {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         Debug::fmt(&BytesRef(self.as_ref()), f)

--- a/src/fmt/hex.rs
+++ b/src/fmt/hex.rs
@@ -1,6 +1,7 @@
 use core::fmt::{Formatter, LowerHex, Result, UpperHex};
 
 use super::BytesRef;
+#[cfg(feature = "alloc")]
 use crate::{Bytes, BytesMut};
 
 impl LowerHex for BytesRef<'_> {
@@ -21,6 +22,7 @@ impl UpperHex for BytesRef<'_> {
     }
 }
 
+#[cfg(feature = "alloc")]
 macro_rules! hex_impl {
     ($tr:ident, $ty:ty) => {
         impl $tr for $ty {
@@ -31,7 +33,11 @@ macro_rules! hex_impl {
     };
 }
 
+#[cfg(feature = "alloc")]
 hex_impl!(LowerHex, Bytes);
+#[cfg(feature = "alloc")]
 hex_impl!(LowerHex, BytesMut);
+#[cfg(feature = "alloc")]
 hex_impl!(UpperHex, Bytes);
+#[cfg(feature = "alloc")]
 hex_impl!(UpperHex, BytesMut);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@
 //! perform a syscall, which has the potential of failing. Operations on `Buf`
 //! and `BufMut` are infallible.
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "std")]
@@ -84,11 +85,15 @@ extern crate std;
 pub mod buf;
 pub use crate::buf::{Buf, BufMut};
 
+#[cfg(feature = "alloc")]
 mod bytes;
+#[cfg(feature = "alloc")]
 mod bytes_mut;
 mod fmt;
 mod loom;
+#[cfg(feature = "alloc")]
 pub use crate::bytes::Bytes;
+#[cfg(feature = "alloc")]
 pub use crate::bytes_mut::BytesMut;
 
 // Optional Serde support

--- a/src/loom.rs
+++ b/src/loom.rs
@@ -1,5 +1,6 @@
 #[cfg(not(all(test, loom)))]
 pub(crate) mod sync {
+    #[cfg(feature = "alloc")]
     pub(crate) mod atomic {
         pub(crate) use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 


### PR DESCRIPTION
Currently the `no_std` support for the crate still depends on `alloc`. However, this is only required for `Bytes` and `BytesMut` data structures and not `Buf` and `BufMut` traits or its other impls. This PR makes `alloc` optional in order to make the crate more suitable for embedded environments.

The main benefit of this change is beeing able to depend only on the `Buf` and `BufMut` traits, which is very usefull not only to embedded environments, but also for other crates that would like to use those traits but don't need `Bytes` and `BytesMut`. I think this would be a good thing, since it encorages everyone to use `bytes` and reduce the number of parallel implementations of this same concept.

As an example usecase, [`rust-mavlink`](https://github.com/mavlink/rust-mavlink/blob/master/src/bytes.rs) had to pretty much reimplement `Buf` and `BufMut` because they don't want a hard dependency on `alloc`.

This PR adds a `alloc` default feature that can be disabled if not required. However, maybe it would be better to add a `embedded` or `no_alloc` feature instead, so that it doesn't break any code that depends on `bytes`. Please let me know what you think of this change.