### PR TITLE
Fix CI failure

### DIFF
--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -72,6 +72,7 @@ fn test_vec_deque() {
     assert_eq!(b"world piece", &out[..]);
 }
 
+#[allow(unused_allocation)] // This is intentional.
 #[test]
 fn test_deref_buf_forwards() {
     struct Special;

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -218,6 +218,7 @@ fn test_maybe_uninit_buf_mut_put_bytes_overflow() {
     do_test_slice_put_bytes_panics(make_maybe_uninit_slice);
 }
 
+#[allow(unused_allocation)] // This is intentional.
 #[test]
 fn test_deref_bufmut_forwards() {
     struct Special;


### PR DESCRIPTION
This fixes [CI failure due to new rust lint](https://github.com/tokio-rs/bytes/actions/runs/5169520538/jobs/9311830087).

```
warning: unnecessary allocation, use `&mut` instead
   --> tests/test_buf_mut.rs:247:5
    |
247 |     Box::new(Special).put_u8(b'x');
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_allocation)]` on by default

warning: unnecessary allocation, use `&mut` instead
   --> tests/test_buf.rs:102:16
    |
102 |     assert_eq!(Box::new(Special).get_u8(), b'x');
    |                ^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_allocation)]` on by default
```