### PR TITLE
add specialized `Buf::chunks_vectored` for `Take`

### DIFF
--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -162,9 +162,29 @@ impl<T: Buf> Buf for Take<T> {
             return 0;
         }
 
-        let mut slices = [IoSlice::new(&[]); 16];
+        const LEN: usize = 16;
+        let mut slices: [IoSlice<'a>; LEN] = [
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+            IoSlice::new(&[]),
+        ];
 
-        let cnt = self.inner.chunks_vectored(&mut slices[..dst.len().min(16)]);
+        let cnt = self
+            .inner
+            .chunks_vectored(&mut slices[..dst.len().min(LEN)]);
         let mut limit = self.limit;
         for (i, (dst, slice)) in dst[..cnt].iter_mut().zip(slices.iter()).enumerate() {
             if let Some(buf) = slice.get(..limit) {

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -192,9 +192,12 @@ impl<T: Buf> Buf for Take<T> {
                 let buf = unsafe { std::mem::transmute::<&[u8], &'a [u8]>(buf) };
                 *dst = IoSlice::new(buf);
                 return i + 1;
+            } else {
+                // SAFETY: We could do this safely with `IoSlice::advance` if we had a larger MSRV.
+                let buf = unsafe { std::mem::transmute::<&[u8], &'a [u8]>(slice) };
+                *dst = IoSlice::new(buf);
+                limit -= slice.len();
             }
-            *dst = *slice;
-            limit -= slice.len();
         }
         cnt
     }

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -162,14 +162,14 @@ impl<T: Buf> Buf for Take<T> {
 
         let cnt = self.inner.chunks_vectored(&mut slices[..dst.len().min(16)]);
         let mut limit = self.limit;
-        for (i, (dst, slice)) in dst[..cnt].iter_mut().zip(slices.iter().copied()).enumerate() {
+        for (i, (dst, slice)) in dst[..cnt].iter_mut().zip(slices.iter()).enumerate() {
             if let Some(buf) = slice.get(..limit) {
                 // SAFETY: We could do this safely with `IoSlice::advance` if we had a larger MSRV.
                 let buf = unsafe { std::mem::transmute::<&[u8], &'a [u8]>(buf) };
                 *dst = IoSlice::new(buf);
                 return i + 1;
             }
-            *dst = slice;
+            *dst = *slice;
             limit -= slice.len();
         }
         cnt

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -158,6 +158,10 @@ impl<T: Buf> Buf for Take<T> {
 
     #[cfg(feature = "std")]
     fn chunks_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
+        if self.limit == 0 {
+            return 0;
+        }
+
         let mut slices = [IoSlice::new(&[]); 16];
 
         let cnt = self.inner.chunks_vectored(&mut slices[..dst.len().min(16)]);

--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -404,7 +404,7 @@ mod chain_limited_slices {
         Buf::take(Buf::chain(Buf::chain(a, b), Buf::chain(c, d)), buf.len())
     }
 
-    buf_tests!(make_input, /* `Limit` does not forward `chucks_vectored */ false);
+    buf_tests!(make_input, true);
 }
 
 #[allow(unused_allocation)] // This is intentional.


### PR DESCRIPTION
The `h2` crate uses `Take` around the data frames to enforce a maximum frame size, which breaks vectored writes since `Take` doesn't provide a specialized `chunks_vectored` that calls the underlying `chunks_vectored`.

To make this work with truncating individual `IoSlice`s, I needed to resort to a tiny bit of `unsafe` code. There is a PR open (rust-lang/rust#111277) which will alleviate the need for it, but that hasn't landed yet (so unlikely to be stable any time soon).

An alternative could be to just remove rather than truncate any `IoSlice` that crosses the limit threshold, which could be accomplished without any unsafe code. However, that might break the following guarantee documented on `chunks_vectored`: "If chunk_vectored does not fill every entry in dst, then dst is guaranteed to contain all remaining slices in `self."

Happy to go either route, let me know what you think!