### PR TITLE
Patch to use portable-atomics for extra-platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,11 @@ edition = "2018"
 [features]
 default = ["std"]
 std = []
+extra-platforms = ["portable-atomic"]
 
 [dependencies]
 serde = { version = "1.0.60", optional = true, default-features = false, features = ["alloc"] }
+portable-atomic = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/src/loom.rs
+++ b/src/loom.rs
@@ -1,7 +1,11 @@
 #[cfg(not(all(test, loom)))]
 pub(crate) mod sync {
     pub(crate) mod atomic {
-        pub(crate) use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+        ub(crate) mod atomic {
+            #[cfg(not(feature = "extra-platforms"))]
+            pub(crate) use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+            #[cfg(feature = "extra-platforms")]
+            pub(crate) use portable_atomic::{AtomicPtr, AtomicUsize, Ordering};
 
         pub(crate) trait AtomicMut<T> {
             fn with_mut<F, R>(&mut self, f: F) -> R


### PR DESCRIPTION
Make `bytes` crate compatible with `thumbv6m-none-eabi` targets (my use case but possibly more)