### PR TITLE
Add specialized get_X impls for Bytes struct to reduce dead code

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -533,6 +533,23 @@ impl Clone for Bytes {
     }
 }
 
+macro_rules! buf_get_impl {
+    ($this:ident, $typ:tt::$conv:tt) => {{
+        const SIZE: usize = mem::size_of::<$typ>();
+        // slice.get() returns None on failing bounds check, resulting in a panic, but skips the unnecessary code of the
+        // default buf impl that needs to account for non-contiguous memory
+        let ret = $this
+            .chunk()
+            .get(..SIZE)
+            .map(|src| unsafe { $typ::$conv(*(src as *const _ as *const [_; SIZE])) })
+            .unwrap();
+
+        // if the direct conversion was possible, advance and return
+        $this.advance(SIZE);
+        return ret;
+    }};
+}
+
 impl Buf for Bytes {
     #[inline]
     fn remaining(&self) -> usize {
@@ -566,6 +583,102 @@ impl Buf for Bytes {
             self.advance(len);
             ret
         }
+    }
+
+    fn get_u16(&mut self) -> u16 {
+        buf_get_impl!(self, u16::from_be_bytes);
+    }
+
+    fn get_u16_le(&mut self) -> u16 {
+        buf_get_impl!(self, u16::from_le_bytes);
+    }
+
+    fn get_u16_ne(&mut self) -> u16 {
+        buf_get_impl!(self, u16::from_ne_bytes);
+    }
+
+    fn get_i16(&mut self) -> i16 {
+        buf_get_impl!(self, i16::from_be_bytes);
+    }
+
+    fn get_i16_le(&mut self) -> i16 {
+        buf_get_impl!(self, i16::from_le_bytes);
+    }
+
+    fn get_i16_ne(&mut self) -> i16 {
+        buf_get_impl!(self, i16::from_ne_bytes);
+    }
+
+    fn get_u32(&mut self) -> u32 {
+        buf_get_impl!(self, u32::from_be_bytes);
+    }
+
+    fn get_u32_le(&mut self) -> u32 {
+        buf_get_impl!(self, u32::from_le_bytes);
+    }
+
+    fn get_u32_ne(&mut self) -> u32 {
+        buf_get_impl!(self, u32::from_ne_bytes);
+    }
+
+    fn get_i32(&mut self) -> i32 {
+        buf_get_impl!(self, i32::from_be_bytes);
+    }
+
+    fn get_i32_le(&mut self) -> i32 {
+        buf_get_impl!(self, i32::from_le_bytes);
+    }
+
+    fn get_i32_ne(&mut self) -> i32 {
+        buf_get_impl!(self, i32::from_ne_bytes);
+    }
+
+    fn get_u64(&mut self) -> u64 {
+        buf_get_impl!(self, u64::from_be_bytes);
+    }
+
+    fn get_u64_le(&mut self) -> u64 {
+        buf_get_impl!(self, u64::from_le_bytes);
+    }
+
+    fn get_u64_ne(&mut self) -> u64 {
+        buf_get_impl!(self, u64::from_ne_bytes);
+    }
+
+    fn get_i64(&mut self) -> i64 {
+        buf_get_impl!(self, i64::from_be_bytes);
+    }
+
+    fn get_i64_le(&mut self) -> i64 {
+        buf_get_impl!(self, i64::from_le_bytes);
+    }
+
+    fn get_i64_ne(&mut self) -> i64 {
+        buf_get_impl!(self, i64::from_ne_bytes);
+    }
+
+    fn get_u128(&mut self) -> u128 {
+        buf_get_impl!(self, u128::from_be_bytes);
+    }
+
+    fn get_u128_le(&mut self) -> u128 {
+        buf_get_impl!(self, u128::from_le_bytes);
+    }
+
+    fn get_u128_ne(&mut self) -> u128 {
+        buf_get_impl!(self, u128::from_ne_bytes);
+    }
+
+    fn get_i128(&mut self) -> i128 {
+        buf_get_impl!(self, i128::from_be_bytes);
+    }
+
+    fn get_i128_le(&mut self) -> i128 {
+        buf_get_impl!(self, i128::from_le_bytes);
+    }
+
+    fn get_i128_ne(&mut self) -> i128 {
+        buf_get_impl!(self, i128::from_ne_bytes);
     }
 }
 

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1208,3 +1208,18 @@ fn test_bytes_capacity_len() {
         }
     }
 }
+
+#[test]
+fn test_get_u16() {
+    let mut buf = Bytes::from(&b"\x21\x54zomg"[..]);
+    assert_eq!(0x2154, buf.get_u16());
+    let mut buf = Bytes::from(&b"\x21\x54zomg"[..]);
+    assert_eq!(0x5421, buf.get_u16_le());
+}
+
+#[test]
+#[should_panic]
+fn test_get_u16_buffer_underflow() {
+    let mut buf = Bytes::from(&b"\x21"[..]);
+    buf.get_u16();
+}


### PR DESCRIPTION
Without this change, there's quite a bit of dead code generated when using these functions with a Bytes object. This is because:

1. These functions are nearly always inlined in their entirety (including the call to `self.copy_to_slice`)

2. The entire conditional: 

```rust
        if let Some(ret) = ret {
            // if the direct conversion was possible, advance and return
            $this.advance(SIZE);
            return ret;
        } else {
            // if not we copy the bytes in a temp buffer then convert
            let mut buf = [0; SIZE];
            $this.copy_to_slice(&mut buf); // (do the advance)
            return $typ::$conv(buf);
        }
```

seems to be meant to handle non-contiguous memory. Bytes is guaranteed to be contiguous, so whenever the `else` block is triggered it immediately panics on `self.copy_to_slice`'s first assert statement.

Due to the above, the generated assembly for multiple sequential `bytes.get_x` calls is pretty messy and it doesn't look like the compiler is having a fun time with it. This simple change removes the conditional and just has a raw panic on a `None` being returned from `slice.get`, cleaning up the generated code a lot.

I also copied the `Buf` `get_u16` tests over to the bytes tests to confirm the behavior still works as expected.