### PR TITLE
chore: prepare v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.5.0 (September 6, 2023)
+# 1.5.0 (September 7, 2023)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.5.0 (September 6, 2023)
+
+### Added
+
+- Add `UninitSlice::{new,init}` (#598, #599)
+- Implement `BufMut` for `&mut [MaybeUninit<u8>]` (#597)
+
+### Changed
+
+- Mark `BytesMut::extend_from_slice` as inline (#595)
+
 # 1.4.0 (January 31, 2023)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bytes"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.4.0"
+version = "1.5.0"
 license = "MIT"
 authors = [
     "Carl Lerche <me@carllerche.com>",


### PR DESCRIPTION
# 1.5.0 (September 7, 2023)

### Added

- Add `UninitSlice::{new,init}` (#598, #599)
- Implement `BufMut` for `&mut [MaybeUninit<u8>]` (#597)

### Changed

- Mark `BytesMut::extend_from_slice` as inline (#595)

Closes: #626