### PR TITLE
Remove ptr_map special casing for miri (#565)

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1221,13 +1221,6 @@ unsafe fn release_shared(ptr: *mut Shared) {
     drop(Box::from_raw(ptr));
 }
 
-// Ideally we would always use this version of `ptr_map` since it is strict
-// provenance compatible, but it results in worse codegen. We will however still
-// use it on miri because it gives better diagnostics for people who test bytes
-// code with miri.
-//
-// See https://github.com/tokio-rs/bytes/pull/545 for more info.
-#[cfg(miri)]
 fn ptr_map<F>(ptr: *mut u8, f: F) -> *mut u8
 where
     F: FnOnce(usize) -> usize,
@@ -1236,16 +1229,6 @@ where
     let new_addr = f(old_addr);
     let diff = new_addr.wrapping_sub(old_addr);
     ptr.wrapping_add(diff)
-}
-
-#[cfg(not(miri))]
-fn ptr_map<F>(ptr: *mut u8, f: F) -> *mut u8
-where
-    F: FnOnce(usize) -> usize,
-{
-    let old_addr = ptr as usize;
-    let new_addr = f(old_addr);
-    new_addr as *mut u8
 }
 
 // compile-fails


### PR DESCRIPTION
Since Rust 1.65, which introduced LLVM 15, codegen for both versions of ptr_map is the same. The release happened in Nov 2022, which should mean the majority of users have upgraded.