### PR TITLE
Various cleanup

### DIFF
--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "std")]
 use crate::buf::{reader, Reader};
 use crate::buf::{take, Chain, Take};
-use crate::{min_u64_usize, panic_advance, panic_does_not_fit, saturating_sub_usize_u64};
+#[cfg(feature = "std")]
+use crate::{min_u64_usize, saturating_sub_usize_u64};
+use crate::{panic_advance, panic_does_not_fit};
 
 #[cfg(feature = "std")]
 use std::io::IoSlice;

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -178,7 +178,6 @@ pub trait Buf {
     /// [`writev`]: http://man7.org/linux/man-pages/man2/readv.2.html
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    #[track_caller]
     fn chunks_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
         if dst.is_empty() {
             return 0;
@@ -266,7 +265,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if `self.remaining() < dst.len()`.
-    #[track_caller]
     fn copy_to_slice(&mut self, mut dst: &mut [u8]) {
         if self.remaining() < dst.len() {
             panic_advance(dst.len(), self.remaining());
@@ -299,7 +297,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is no more remaining data in `self`.
-    #[track_caller]
     fn get_u8(&mut self) -> u8 {
         if self.remaining() < 1 {
             panic_advance(1, 0);
@@ -325,7 +322,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is no more remaining data in `self`.
-    #[track_caller]
     fn get_i8(&mut self) -> i8 {
         if self.remaining() < 1 {
             panic_advance(1, 0);
@@ -351,7 +347,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_u16(&mut self) -> u16 {
         buf_get_impl!(self, u16::from_be_bytes);
     }
@@ -372,7 +367,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_u16_le(&mut self) -> u16 {
         buf_get_impl!(self, u16::from_le_bytes);
     }
@@ -396,7 +390,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_u16_ne(&mut self) -> u16 {
         buf_get_impl!(self, u16::from_ne_bytes);
     }
@@ -417,7 +410,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_i16(&mut self) -> i16 {
         buf_get_impl!(self, i16::from_be_bytes);
     }
@@ -438,7 +430,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_i16_le(&mut self) -> i16 {
         buf_get_impl!(self, i16::from_le_bytes);
     }
@@ -462,7 +453,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_i16_ne(&mut self) -> i16 {
         buf_get_impl!(self, i16::from_ne_bytes);
     }
@@ -483,7 +473,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_u32(&mut self) -> u32 {
         buf_get_impl!(self, u32::from_be_bytes);
     }
@@ -504,7 +493,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_u32_le(&mut self) -> u32 {
         buf_get_impl!(self, u32::from_le_bytes);
     }
@@ -528,7 +516,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_u32_ne(&mut self) -> u32 {
         buf_get_impl!(self, u32::from_ne_bytes);
     }
@@ -549,7 +536,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_i32(&mut self) -> i32 {
         buf_get_impl!(self, i32::from_be_bytes);
     }
@@ -570,7 +556,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_i32_le(&mut self) -> i32 {
         buf_get_impl!(self, i32::from_le_bytes);
     }
@@ -594,7 +579,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_i32_ne(&mut self) -> i32 {
         buf_get_impl!(self, i32::from_ne_bytes);
     }
@@ -615,7 +599,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_u64(&mut self) -> u64 {
         buf_get_impl!(self, u64::from_be_bytes);
     }
@@ -636,7 +619,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_u64_le(&mut self) -> u64 {
         buf_get_impl!(self, u64::from_le_bytes);
     }
@@ -660,7 +642,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_u64_ne(&mut self) -> u64 {
         buf_get_impl!(self, u64::from_ne_bytes);
     }
@@ -681,7 +662,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_i64(&mut self) -> i64 {
         buf_get_impl!(self, i64::from_be_bytes);
     }
@@ -702,7 +682,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_i64_le(&mut self) -> i64 {
         buf_get_impl!(self, i64::from_le_bytes);
     }
@@ -726,7 +705,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_i64_ne(&mut self) -> i64 {
         buf_get_impl!(self, i64::from_ne_bytes);
     }
@@ -747,7 +725,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_u128(&mut self) -> u128 {
         buf_get_impl!(self, u128::from_be_bytes);
     }
@@ -768,7 +745,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_u128_le(&mut self) -> u128 {
         buf_get_impl!(self, u128::from_le_bytes);
     }
@@ -792,7 +768,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_u128_ne(&mut self) -> u128 {
         buf_get_impl!(self, u128::from_ne_bytes);
     }
@@ -813,7 +788,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_i128(&mut self) -> i128 {
         buf_get_impl!(self, i128::from_be_bytes);
     }
@@ -834,7 +808,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_i128_le(&mut self) -> i128 {
         buf_get_impl!(self, i128::from_le_bytes);
     }
@@ -858,7 +831,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_i128_ne(&mut self) -> i128 {
         buf_get_impl!(self, i128::from_ne_bytes);
     }
@@ -879,7 +851,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_uint(&mut self, nbytes: usize) -> u64 {
         buf_get_impl!(be => self, u64, nbytes);
     }
@@ -900,7 +871,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_uint_le(&mut self, nbytes: usize) -> u64 {
         buf_get_impl!(le => self, u64, nbytes);
     }
@@ -925,7 +895,6 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`, or
     /// if `nbytes` is greater than 8.
-    #[track_caller]
     fn get_uint_ne(&mut self, nbytes: usize) -> u64 {
         if cfg!(target_endian = "big") {
             self.get_uint(nbytes)
@@ -951,7 +920,6 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`, or
     /// if `nbytes` is greater than 8.
-    #[track_caller]
     fn get_int(&mut self, nbytes: usize) -> i64 {
         buf_get_impl!(be => self, i64, nbytes);
     }
@@ -973,7 +941,6 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`, or
     /// if `nbytes` is greater than 8.
-    #[track_caller]
     fn get_int_le(&mut self, nbytes: usize) -> i64 {
         buf_get_impl!(le => self, i64, nbytes);
     }
@@ -998,7 +965,6 @@ pub trait Buf {
     ///
     /// This function panics if there is not enough remaining data in `self`, or
     /// if `nbytes` is greater than 8.
-    #[track_caller]
     fn get_int_ne(&mut self, nbytes: usize) -> i64 {
         if cfg!(target_endian = "big") {
             self.get_int(nbytes)
@@ -1024,7 +990,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_f32(&mut self) -> f32 {
         f32::from_bits(Self::get_u32(self))
     }
@@ -1046,7 +1011,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_f32_le(&mut self) -> f32 {
         f32::from_bits(Self::get_u32_le(self))
     }
@@ -1071,7 +1035,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_f32_ne(&mut self) -> f32 {
         f32::from_bits(Self::get_u32_ne(self))
     }
@@ -1093,7 +1056,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_f64(&mut self) -> f64 {
         f64::from_bits(Self::get_u64(self))
     }
@@ -1115,7 +1077,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_f64_le(&mut self) -> f64 {
         f64::from_bits(Self::get_u64_le(self))
     }
@@ -1140,7 +1101,6 @@ pub trait Buf {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    #[track_caller]
     fn get_f64_ne(&mut self) -> f64 {
         f64::from_bits(Self::get_u64_ne(self))
     }
@@ -1160,7 +1120,6 @@ pub trait Buf {
     /// let bytes = (&b"hello world"[..]).copy_to_bytes(5);
     /// assert_eq!(&bytes[..], &b"hello"[..]);
     /// ```
-    #[track_caller]
     fn copy_to_bytes(&mut self, len: usize) -> crate::Bytes {
         use super::BufMut;
 
@@ -1258,200 +1217,167 @@ pub trait Buf {
 
 macro_rules! deref_forward_buf {
     () => {
-        #[track_caller]
         #[inline]
         fn remaining(&self) -> usize {
             (**self).remaining()
         }
 
-        #[track_caller]
         #[inline]
         fn chunk(&self) -> &[u8] {
             (**self).chunk()
         }
 
         #[cfg(feature = "std")]
-        #[track_caller]
         #[inline]
         fn chunks_vectored<'b>(&'b self, dst: &mut [IoSlice<'b>]) -> usize {
             (**self).chunks_vectored(dst)
         }
 
-        #[track_caller]
         #[inline]
         fn advance(&mut self, cnt: usize) {
             (**self).advance(cnt)
         }
 
-        #[track_caller]
         #[inline]
         fn has_remaining(&self) -> bool {
             (**self).has_remaining()
         }
 
-        #[track_caller]
         #[inline]
         fn copy_to_slice(&mut self, dst: &mut [u8]) {
             (**self).copy_to_slice(dst)
         }
 
-        #[track_caller]
         #[inline]
         fn get_u8(&mut self) -> u8 {
             (**self).get_u8()
         }
 
-        #[track_caller]
         #[inline]
         fn get_i8(&mut self) -> i8 {
             (**self).get_i8()
         }
 
-        #[track_caller]
         #[inline]
         fn get_u16(&mut self) -> u16 {
             (**self).get_u16()
         }
 
-        #[track_caller]
         #[inline]
         fn get_u16_le(&mut self) -> u16 {
             (**self).get_u16_le()
         }
 
-        #[track_caller]
         #[inline]
         fn get_u16_ne(&mut self) -> u16 {
             (**self).get_u16_ne()
         }
 
-        #[track_caller]
         #[inline]
         fn get_i16(&mut self) -> i16 {
             (**self).get_i16()
         }
 
-        #[track_caller]
         #[inline]
         fn get_i16_le(&mut self) -> i16 {
             (**self).get_i16_le()
         }
 
-        #[track_caller]
         #[inline]
         fn get_i16_ne(&mut self) -> i16 {
             (**self).get_i16_ne()
         }
 
-        #[track_caller]
         #[inline]
         fn get_u32(&mut self) -> u32 {
             (**self).get_u32()
         }
 
-        #[track_caller]
         #[inline]
         fn get_u32_le(&mut self) -> u32 {
             (**self).get_u32_le()
         }
 
-        #[track_caller]
         #[inline]
         fn get_u32_ne(&mut self) -> u32 {
             (**self).get_u32_ne()
         }
 
-        #[track_caller]
         #[inline]
         fn get_i32(&mut self) -> i32 {
             (**self).get_i32()
         }
 
-        #[track_caller]
         #[inline]
         fn get_i32_le(&mut self) -> i32 {
             (**self).get_i32_le()
         }
 
-        #[track_caller]
         #[inline]
         fn get_i32_ne(&mut self) -> i32 {
             (**self).get_i32_ne()
         }
 
-        #[track_caller]
         #[inline]
         fn get_u64(&mut self) -> u64 {
             (**self).get_u64()
         }
 
-        #[track_caller]
         #[inline]
         fn get_u64_le(&mut self) -> u64 {
             (**self).get_u64_le()
         }
 
-        #[track_caller]
         #[inline]
         fn get_u64_ne(&mut self) -> u64 {
             (**self).get_u64_ne()
         }
 
-        #[track_caller]
         #[inline]
         fn get_i64(&mut self) -> i64 {
             (**self).get_i64()
         }
 
-        #[track_caller]
         #[inline]
         fn get_i64_le(&mut self) -> i64 {
             (**self).get_i64_le()
         }
 
-        #[track_caller]
         #[inline]
         fn get_i64_ne(&mut self) -> i64 {
             (**self).get_i64_ne()
         }
 
-        #[track_caller]
         #[inline]
         fn get_uint(&mut self, nbytes: usize) -> u64 {
             (**self).get_uint(nbytes)
         }
 
-        #[track_caller]
         #[inline]
         fn get_uint_le(&mut self, nbytes: usize) -> u64 {
             (**self).get_uint_le(nbytes)
         }
 
-        #[track_caller]
         #[inline]
         fn get_uint_ne(&mut self, nbytes: usize) -> u64 {
             (**self).get_uint_ne(nbytes)
         }
 
-        #[track_caller]
         #[inline]
         fn get_int(&mut self, nbytes: usize) -> i64 {
             (**self).get_int(nbytes)
         }
 
-        #[track_caller]
         #[inline]
         fn get_int_le(&mut self, nbytes: usize) -> i64 {
             (**self).get_int_le(nbytes)
         }
 
-        #[track_caller]
         #[inline]
         fn get_int_ne(&mut self, nbytes: usize) -> i64 {
             (**self).get_int_ne(nbytes)
         }
 
-        #[track_caller]
         #[inline]
         fn copy_to_bytes(&mut self, len: usize) -> crate::Bytes {
             (**self).copy_to_bytes(len)
@@ -1479,7 +1405,6 @@ impl Buf for &[u8] {
     }
 
     #[inline]
-    #[track_caller]
     fn advance(&mut self, cnt: usize) {
         if self.len() < cnt {
             panic_advance(cnt, self.len());
@@ -1489,7 +1414,6 @@ impl Buf for &[u8] {
     }
 
     #[inline]
-    #[track_caller]
     fn copy_to_slice(&mut self, dst: &mut [u8]) {
         if self.len() < dst.len() {
             panic_advance(dst.len(), self.len());
@@ -1508,7 +1432,6 @@ impl<T: AsRef<[u8]>> Buf for std::io::Cursor<T> {
     }
 
     #[inline]
-    #[track_caller]
     fn chunk(&self) -> &[u8] {
         let slice = self.get_ref().as_ref();
         let pos = min_u64_usize(self.position(), slice.len());
@@ -1516,7 +1439,6 @@ impl<T: AsRef<[u8]>> Buf for std::io::Cursor<T> {
     }
 
     #[inline]
-    #[track_caller]
     fn advance(&mut self, cnt: usize) {
         let len = self.get_ref().as_ref().len();
         let pos = self.position();

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "std")]
 use crate::buf::{reader, Reader};
 use crate::buf::{take, Chain, Take};
-use crate::{panic_advance, panic_does_not_fit, saturating_sub_usize_u64, min_u64_usize};
+use crate::{min_u64_usize, panic_advance, panic_does_not_fit, saturating_sub_usize_u64};
 
 #[cfg(feature = "std")]
 use std::io::IoSlice;

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -1,8 +1,9 @@
 use crate::buf::{limit, Chain, Limit, UninitSlice};
 #[cfg(feature = "std")]
 use crate::buf::{writer, Writer};
+use crate::{panic_advance, panic_does_not_fit};
 
-use core::{cmp, mem, ptr, usize};
+use core::{mem, ptr, usize};
 
 use alloc::{boxed::Box, vec::Vec};
 
@@ -67,8 +68,10 @@ pub unsafe trait BufMut {
     /// The next call to `chunk_mut` will return a slice starting `cnt` bytes
     /// further into the underlying buffer.
     ///
-    /// This function is unsafe because there is no guarantee that the bytes
-    /// being advanced past have been initialized.
+    /// # Safety
+    ///
+    /// The caller must ensure that the next `cnt` bytes of `chunk` are
+    /// initialized.
     ///
     /// # Examples
     ///
@@ -121,6 +124,7 @@ pub unsafe trait BufMut {
     ///
     /// assert!(!buf.has_remaining_mut());
     /// ```
+    #[inline]
     fn has_remaining_mut(&self) -> bool {
         self.remaining_mut() > 0
     }
@@ -194,27 +198,26 @@ pub unsafe trait BufMut {
     /// # Panics
     ///
     /// Panics if `self` does not have enough capacity to contain `src`.
+    #[inline]
+    #[track_caller]
     fn put<T: super::Buf>(&mut self, mut src: T)
     where
         Self: Sized,
     {
-        assert!(self.remaining_mut() >= src.remaining());
+        if self.remaining_mut() < src.remaining() {
+            panic_advance(src.remaining(), self.remaining_mut());
+        }
 
         while src.has_remaining() {
-            let l;
+            let s = src.chunk();
+            let d = self.chunk_mut();
+            let cnt = usize::min(s.len(), d.len());
 
-            unsafe {
-                let s = src.chunk();
-                let d = self.chunk_mut();
-                l = cmp::min(s.len(), d.len());
+            d[..cnt].copy_from_slice(&s[..cnt]);
 
-                ptr::copy_nonoverlapping(s.as_ptr(), d.as_mut_ptr() as *mut u8, l);
-            }
-
-            src.advance(l);
-            unsafe {
-                self.advance_mut(l);
-            }
+            // SAFETY: We just initialized `cnt` bytes in `self`.
+            unsafe { self.advance_mut(cnt) };
+            src.advance(cnt);
         }
     }
 
@@ -237,31 +240,22 @@ pub unsafe trait BufMut {
     ///
     /// assert_eq!(b"hello\0", &dst);
     /// ```
-    fn put_slice(&mut self, src: &[u8]) {
-        let mut off = 0;
+    #[inline]
+    #[track_caller]
+    fn put_slice(&mut self, mut src: &[u8]) {
+        if self.remaining_mut() < src.len() {
+            panic_advance(src.len(), self.remaining_mut());
+        }
 
-        assert!(
-            self.remaining_mut() >= src.len(),
-            "buffer overflow; remaining = {}; src = {}",
-            self.remaining_mut(),
-            src.len()
-        );
+        while !src.is_empty() {
+            let dst = self.chunk_mut();
+            let cnt = usize::min(src.len(), dst.len());
 
-        while off < src.len() {
-            let cnt;
+            dst[..cnt].copy_from_slice(&src[..cnt]);
+            src = &src[cnt..];
 
-            unsafe {
-                let dst = self.chunk_mut();
-                cnt = cmp::min(dst.len(), src.len() - off);
-
-                ptr::copy_nonoverlapping(src[off..].as_ptr(), dst.as_mut_ptr() as *mut u8, cnt);
-
-                off += cnt;
-            }
-
-            unsafe {
-                self.advance_mut(cnt);
-            }
+            // SAFETY: We just initialized `cnt` bytes in `self`.
+            unsafe { self.advance_mut(cnt) };
         }
     }
 
@@ -290,9 +284,21 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_bytes(&mut self, val: u8, cnt: usize) {
-        for _ in 0..cnt {
-            self.put_u8(val);
+    #[inline]
+    #[track_caller]
+    fn put_bytes(&mut self, val: u8, mut cnt: usize) {
+        if self.remaining_mut() < cnt {
+            panic_advance(cnt, self.remaining_mut());
+        }
+
+        while cnt > 0 {
+            let dst = self.chunk_mut();
+            let dst_len = usize::min(dst.len(), cnt);
+            // SAFETY: The pointer is valid for `dst_len <= dst.len()` bytes.
+            unsafe { core::ptr::write_bytes(dst.as_mut_ptr(), val, dst_len) };
+            // SAFETY: We just initialized `dst_len` bytes in `self`.
+            unsafe { self.advance_mut(dst_len) };
+            cnt -= dst_len;
         }
     }
 
@@ -314,6 +320,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u8(&mut self, n: u8) {
         let src = [n];
         self.put_slice(&src);
@@ -337,6 +345,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i8(&mut self, n: i8) {
         let src = [n as u8];
         self.put_slice(&src)
@@ -360,6 +370,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u16(&mut self, n: u16) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -382,6 +394,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u16_le(&mut self, n: u16) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -408,6 +422,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u16_ne(&mut self, n: u16) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -430,6 +446,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i16(&mut self, n: i16) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -452,6 +470,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i16_le(&mut self, n: i16) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -478,6 +498,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i16_ne(&mut self, n: i16) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -500,6 +522,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u32(&mut self, n: u32) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -522,6 +546,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u32_le(&mut self, n: u32) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -548,6 +574,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u32_ne(&mut self, n: u32) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -570,6 +598,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i32(&mut self, n: i32) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -592,6 +622,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i32_le(&mut self, n: i32) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -618,6 +650,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i32_ne(&mut self, n: i32) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -640,6 +674,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u64(&mut self, n: u64) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -662,6 +698,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u64_le(&mut self, n: u64) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -688,6 +726,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u64_ne(&mut self, n: u64) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -710,6 +750,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i64(&mut self, n: i64) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -732,6 +774,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i64_le(&mut self, n: i64) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -758,6 +802,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i64_ne(&mut self, n: i64) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -780,6 +826,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u128(&mut self, n: u128) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -802,6 +850,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u128_le(&mut self, n: u128) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -828,6 +878,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_u128_ne(&mut self, n: u128) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -850,6 +902,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i128(&mut self, n: i128) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -872,6 +926,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i128_le(&mut self, n: i128) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -898,6 +954,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_i128_ne(&mut self, n: i128) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -919,9 +977,16 @@ pub unsafe trait BufMut {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining capacity in
-    /// `self`.
+    /// `self` or if `nbytes` is greater than 8.
+    #[inline]
+    #[track_caller]
     fn put_uint(&mut self, n: u64, nbytes: usize) {
-        self.put_slice(&n.to_be_bytes()[mem::size_of_val(&n) - nbytes..]);
+        let start = match mem::size_of_val(&n).checked_sub(nbytes) {
+            Some(start) => start,
+            None => panic_does_not_fit(nbytes, mem::size_of_val(&n)),
+        };
+
+        self.put_slice(&n.to_be_bytes()[start..]);
     }
 
     /// Writes an unsigned n-byte integer to `self` in the little-endian byte order.
@@ -941,9 +1006,17 @@ pub unsafe trait BufMut {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining capacity in
-    /// `self`.
+    /// `self` or if `nbytes` is greater than 8.
+    #[inline]
+    #[track_caller]
     fn put_uint_le(&mut self, n: u64, nbytes: usize) {
-        self.put_slice(&n.to_le_bytes()[0..nbytes]);
+        let slice = n.to_le_bytes();
+        let slice = match slice.get(..nbytes) {
+            Some(slice) => slice,
+            None => panic_does_not_fit(nbytes, slice.len()),
+        };
+
+        self.put_slice(slice);
     }
 
     /// Writes an unsigned n-byte integer to `self` in the native-endian byte order.
@@ -967,7 +1040,9 @@ pub unsafe trait BufMut {
     /// # Panics
     ///
     /// This function panics if there is not enough remaining capacity in
-    /// `self`.
+    /// `self` or if `nbytes` is greater than 8.
+    #[inline]
+    #[track_caller]
     fn put_uint_ne(&mut self, n: u64, nbytes: usize) {
         if cfg!(target_endian = "big") {
             self.put_uint(n, nbytes)
@@ -994,8 +1069,15 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self` or if `nbytes` is greater than 8.
+    #[inline]
+    #[track_caller]
     fn put_int(&mut self, n: i64, nbytes: usize) {
-        self.put_slice(&n.to_be_bytes()[mem::size_of_val(&n) - nbytes..]);
+        let start = match mem::size_of_val(&n).checked_sub(nbytes) {
+            Some(start) => start,
+            None => panic_does_not_fit(nbytes, mem::size_of_val(&n)),
+        };
+
+        self.put_slice(&n.to_be_bytes()[start..]);
     }
 
     /// Writes low `nbytes` of a signed integer to `self` in little-endian byte order.
@@ -1016,8 +1098,16 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self` or if `nbytes` is greater than 8.
+    #[inline]
+    #[track_caller]
     fn put_int_le(&mut self, n: i64, nbytes: usize) {
-        self.put_slice(&n.to_le_bytes()[0..nbytes]);
+        let slice = n.to_le_bytes();
+        let slice = match slice.get(..nbytes) {
+            Some(slice) => slice,
+            None => panic_does_not_fit(nbytes, slice.len()),
+        };
+
+        self.put_slice(slice);
     }
 
     /// Writes low `nbytes` of a signed integer to `self` in native-endian byte order.
@@ -1042,6 +1132,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self` or if `nbytes` is greater than 8.
+    #[inline]
+    #[track_caller]
     fn put_int_ne(&mut self, n: i64, nbytes: usize) {
         if cfg!(target_endian = "big") {
             self.put_int(n, nbytes)
@@ -1069,6 +1161,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_f32(&mut self, n: f32) {
         self.put_u32(n.to_bits());
     }
@@ -1092,6 +1186,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_f32_le(&mut self, n: f32) {
         self.put_u32_le(n.to_bits());
     }
@@ -1119,6 +1215,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_f32_ne(&mut self, n: f32) {
         self.put_u32_ne(n.to_bits());
     }
@@ -1142,6 +1240,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_f64(&mut self, n: f64) {
         self.put_u64(n.to_bits());
     }
@@ -1165,6 +1265,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_f64_le(&mut self, n: f64) {
         self.put_u64_le(n.to_bits());
     }
@@ -1192,6 +1294,8 @@ pub unsafe trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
+    #[inline]
+    #[track_caller]
     fn put_f64_ne(&mut self, n: f64) {
         self.put_u64_ne(n.to_bits());
     }
@@ -1209,6 +1313,7 @@ pub unsafe trait BufMut {
     /// let dst = arr.limit(10);
     /// assert_eq!(dst.remaining_mut(), 10);
     /// ```
+    #[inline]
     fn limit(self, limit: usize) -> Limit<Self>
     where
         Self: Sized,
@@ -1240,6 +1345,7 @@ pub unsafe trait BufMut {
     /// ```
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    #[inline]
     fn writer(self) -> Writer<Self>
     where
         Self: Sized,
@@ -1267,6 +1373,7 @@ pub unsafe trait BufMut {
     /// assert_eq!(&a[..], b"hello");
     /// assert_eq!(&b[..], b" world");
     /// ```
+    #[inline]
     fn chain_mut<U: BufMut>(self, next: U) -> Chain<Self, U>
     where
         Self: Sized,
@@ -1277,98 +1384,146 @@ pub unsafe trait BufMut {
 
 macro_rules! deref_forward_bufmut {
     () => {
+        #[inline]
+        #[track_caller]
         fn remaining_mut(&self) -> usize {
             (**self).remaining_mut()
         }
 
+        #[inline]
+        #[track_caller]
         fn chunk_mut(&mut self) -> &mut UninitSlice {
             (**self).chunk_mut()
         }
 
+        #[inline]
+        #[track_caller]
         unsafe fn advance_mut(&mut self, cnt: usize) {
             (**self).advance_mut(cnt)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_slice(&mut self, src: &[u8]) {
             (**self).put_slice(src)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_u8(&mut self, n: u8) {
             (**self).put_u8(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_i8(&mut self, n: i8) {
             (**self).put_i8(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_u16(&mut self, n: u16) {
             (**self).put_u16(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_u16_le(&mut self, n: u16) {
             (**self).put_u16_le(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_u16_ne(&mut self, n: u16) {
             (**self).put_u16_ne(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_i16(&mut self, n: i16) {
             (**self).put_i16(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_i16_le(&mut self, n: i16) {
             (**self).put_i16_le(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_i16_ne(&mut self, n: i16) {
             (**self).put_i16_ne(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_u32(&mut self, n: u32) {
             (**self).put_u32(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_u32_le(&mut self, n: u32) {
             (**self).put_u32_le(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_u32_ne(&mut self, n: u32) {
             (**self).put_u32_ne(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_i32(&mut self, n: i32) {
             (**self).put_i32(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_i32_le(&mut self, n: i32) {
             (**self).put_i32_le(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_i32_ne(&mut self, n: i32) {
             (**self).put_i32_ne(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_u64(&mut self, n: u64) {
             (**self).put_u64(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_u64_le(&mut self, n: u64) {
             (**self).put_u64_le(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_u64_ne(&mut self, n: u64) {
             (**self).put_u64_ne(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_i64(&mut self, n: i64) {
             (**self).put_i64(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_i64_le(&mut self, n: i64) {
             (**self).put_i64_le(n)
         }
 
+        #[inline]
+        #[track_caller]
         fn put_i64_ne(&mut self, n: i64) {
             (**self).put_i64_ne(n)
         }
@@ -1391,27 +1546,41 @@ unsafe impl BufMut for &mut [u8] {
 
     #[inline]
     fn chunk_mut(&mut self) -> &mut UninitSlice {
-        // UninitSlice is repr(transparent), so safe to transmute
-        unsafe { &mut *(*self as *mut [u8] as *mut _) }
+        UninitSlice::new(self)
     }
 
     #[inline]
+    #[track_caller]
     unsafe fn advance_mut(&mut self, cnt: usize) {
+        if self.len() < cnt {
+            panic_advance(cnt, self.len());
+        }
+
         // Lifetime dance taken from `impl Write for &mut [u8]`.
         let (_, b) = core::mem::replace(self, &mut []).split_at_mut(cnt);
         *self = b;
     }
 
     #[inline]
+    #[track_caller]
     fn put_slice(&mut self, src: &[u8]) {
-        self[..src.len()].copy_from_slice(src);
-        unsafe {
-            self.advance_mut(src.len());
+        if self.len() < src.len() {
+            panic_advance(src.len(), self.len());
         }
+
+        self[..src.len()].copy_from_slice(src);
+        // SAFETY: We just initialized `src.len()` bytes.
+        unsafe { self.advance_mut(src.len()) };
     }
 
+    #[inline]
+    #[track_caller]
     fn put_bytes(&mut self, val: u8, cnt: usize) {
-        assert!(self.remaining_mut() >= cnt);
+        if self.len() < cnt {
+            panic_advance(cnt, self.len());
+        }
+
+        // SAFETY: We just checked that the pointer is valid for `cnt` bytes.
         unsafe {
             ptr::write_bytes(self.as_mut_ptr(), val, cnt);
             self.advance_mut(cnt);
@@ -1421,32 +1590,51 @@ unsafe impl BufMut for &mut [u8] {
 
 unsafe impl BufMut for &mut [core::mem::MaybeUninit<u8>] {
     #[inline]
+    #[track_caller]
     fn remaining_mut(&self) -> usize {
         self.len()
     }
 
     #[inline]
+    #[track_caller]
     fn chunk_mut(&mut self) -> &mut UninitSlice {
         UninitSlice::uninit(self)
     }
 
     #[inline]
+    #[track_caller]
     unsafe fn advance_mut(&mut self, cnt: usize) {
+        if self.len() < cnt {
+            panic_advance(cnt, self.len());
+        }
+
         // Lifetime dance taken from `impl Write for &mut [u8]`.
         let (_, b) = core::mem::replace(self, &mut []).split_at_mut(cnt);
         *self = b;
     }
 
     #[inline]
+    #[track_caller]
     fn put_slice(&mut self, src: &[u8]) {
-        self.chunk_mut()[..src.len()].copy_from_slice(src);
+        if self.len() < src.len() {
+            panic_advance(src.len(), self.len());
+        }
+
+        // SAFETY: We just checked that the pointer is valid for `src.len()` bytes.
         unsafe {
+            ptr::copy_nonoverlapping(src.as_ptr(), self.as_mut_ptr().cast(), src.len());
             self.advance_mut(src.len());
         }
     }
 
+    #[inline]
+    #[track_caller]
     fn put_bytes(&mut self, val: u8, cnt: usize) {
-        assert!(self.remaining_mut() >= cnt);
+        if self.len() < cnt {
+            panic_advance(cnt, self.len());
+        }
+
+        // SAFETY: We just checked that the pointer is valid for `cnt` bytes.
         unsafe {
             ptr::write_bytes(self.as_mut_ptr() as *mut u8, val, cnt);
             self.advance_mut(cnt);
@@ -1462,17 +1650,16 @@ unsafe impl BufMut for Vec<u8> {
     }
 
     #[inline]
+    #[track_caller]
     unsafe fn advance_mut(&mut self, cnt: usize) {
         let len = self.len();
         let remaining = self.capacity() - len;
 
-        assert!(
-            cnt <= remaining,
-            "cannot advance past `remaining_mut`: {:?} <= {:?}",
-            cnt,
-            remaining
-        );
+        if remaining < cnt {
+            panic_advance(cnt, remaining);
+        }
 
+        // Addition will not overflow since the sum is at most the capacity.
         self.set_len(len + cnt);
     }
 
@@ -1486,28 +1673,26 @@ unsafe impl BufMut for Vec<u8> {
         let len = self.len();
 
         let ptr = self.as_mut_ptr();
-        unsafe { &mut UninitSlice::from_raw_parts_mut(ptr, cap)[len..] }
+        // SAFETY: Since `ptr` is valid for `cap` bytes, `ptr.add(len)` must be
+        // valid for `cap - len` bytes. The subtraction will not underflow since
+        // `len <= cap`.
+        unsafe { UninitSlice::from_raw_parts_mut(ptr.add(len), cap - len) }
     }
 
     // Specialize these methods so they can skip checking `remaining_mut`
     // and `advance_mut`.
+    #[inline]
     fn put<T: super::Buf>(&mut self, mut src: T)
     where
         Self: Sized,
     {
-        // In case the src isn't contiguous, reserve upfront
+        // In case the src isn't contiguous, reserve upfront.
         self.reserve(src.remaining());
 
         while src.has_remaining() {
-            let l;
-
-            // a block to contain the src.bytes() borrow
-            {
-                let s = src.chunk();
-                l = s.len();
-                self.extend_from_slice(s);
-            }
-
+            let s = src.chunk();
+            let l = s.len();
+            self.extend_from_slice(s);
             src.advance(l);
         }
     }
@@ -1517,8 +1702,10 @@ unsafe impl BufMut for Vec<u8> {
         self.extend_from_slice(src);
     }
 
+    #[inline]
     fn put_bytes(&mut self, val: u8, cnt: usize) {
-        let new_len = self.len().checked_add(cnt).unwrap();
+        // If the addition overflows, then the `resize` will fail.
+        let new_len = self.len().saturating_add(cnt);
         self.resize(new_len, val);
     }
 }

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -199,7 +199,6 @@ pub unsafe trait BufMut {
     ///
     /// Panics if `self` does not have enough capacity to contain `src`.
     #[inline]
-    #[track_caller]
     fn put<T: super::Buf>(&mut self, mut src: T)
     where
         Self: Sized,
@@ -241,7 +240,6 @@ pub unsafe trait BufMut {
     /// assert_eq!(b"hello\0", &dst);
     /// ```
     #[inline]
-    #[track_caller]
     fn put_slice(&mut self, mut src: &[u8]) {
         if self.remaining_mut() < src.len() {
             panic_advance(src.len(), self.remaining_mut());
@@ -285,7 +283,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_bytes(&mut self, val: u8, mut cnt: usize) {
         if self.remaining_mut() < cnt {
             panic_advance(cnt, self.remaining_mut());
@@ -321,7 +318,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u8(&mut self, n: u8) {
         let src = [n];
         self.put_slice(&src);
@@ -346,7 +342,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i8(&mut self, n: i8) {
         let src = [n as u8];
         self.put_slice(&src)
@@ -371,7 +366,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u16(&mut self, n: u16) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -395,7 +389,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u16_le(&mut self, n: u16) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -423,7 +416,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u16_ne(&mut self, n: u16) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -447,7 +439,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i16(&mut self, n: i16) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -471,7 +462,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i16_le(&mut self, n: i16) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -499,7 +489,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i16_ne(&mut self, n: i16) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -523,7 +512,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u32(&mut self, n: u32) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -547,7 +535,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u32_le(&mut self, n: u32) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -575,7 +562,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u32_ne(&mut self, n: u32) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -599,7 +585,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i32(&mut self, n: i32) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -623,7 +608,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i32_le(&mut self, n: i32) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -651,7 +635,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i32_ne(&mut self, n: i32) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -675,7 +658,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u64(&mut self, n: u64) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -699,7 +681,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u64_le(&mut self, n: u64) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -727,7 +708,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u64_ne(&mut self, n: u64) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -751,7 +731,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i64(&mut self, n: i64) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -775,7 +754,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i64_le(&mut self, n: i64) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -803,7 +781,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i64_ne(&mut self, n: i64) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -827,7 +804,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u128(&mut self, n: u128) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -851,7 +827,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u128_le(&mut self, n: u128) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -879,7 +854,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_u128_ne(&mut self, n: u128) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -903,7 +877,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i128(&mut self, n: i128) {
         self.put_slice(&n.to_be_bytes())
     }
@@ -927,7 +900,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i128_le(&mut self, n: i128) {
         self.put_slice(&n.to_le_bytes())
     }
@@ -955,7 +927,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_i128_ne(&mut self, n: i128) {
         self.put_slice(&n.to_ne_bytes())
     }
@@ -979,7 +950,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self` or if `nbytes` is greater than 8.
     #[inline]
-    #[track_caller]
     fn put_uint(&mut self, n: u64, nbytes: usize) {
         let start = match mem::size_of_val(&n).checked_sub(nbytes) {
             Some(start) => start,
@@ -1008,7 +978,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self` or if `nbytes` is greater than 8.
     #[inline]
-    #[track_caller]
     fn put_uint_le(&mut self, n: u64, nbytes: usize) {
         let slice = n.to_le_bytes();
         let slice = match slice.get(..nbytes) {
@@ -1042,7 +1011,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self` or if `nbytes` is greater than 8.
     #[inline]
-    #[track_caller]
     fn put_uint_ne(&mut self, n: u64, nbytes: usize) {
         if cfg!(target_endian = "big") {
             self.put_uint(n, nbytes)
@@ -1070,7 +1038,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self` or if `nbytes` is greater than 8.
     #[inline]
-    #[track_caller]
     fn put_int(&mut self, n: i64, nbytes: usize) {
         let start = match mem::size_of_val(&n).checked_sub(nbytes) {
             Some(start) => start,
@@ -1099,7 +1066,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self` or if `nbytes` is greater than 8.
     #[inline]
-    #[track_caller]
     fn put_int_le(&mut self, n: i64, nbytes: usize) {
         let slice = n.to_le_bytes();
         let slice = match slice.get(..nbytes) {
@@ -1133,7 +1099,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self` or if `nbytes` is greater than 8.
     #[inline]
-    #[track_caller]
     fn put_int_ne(&mut self, n: i64, nbytes: usize) {
         if cfg!(target_endian = "big") {
             self.put_int(n, nbytes)
@@ -1162,7 +1127,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_f32(&mut self, n: f32) {
         self.put_u32(n.to_bits());
     }
@@ -1187,7 +1151,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_f32_le(&mut self, n: f32) {
         self.put_u32_le(n.to_bits());
     }
@@ -1216,7 +1179,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_f32_ne(&mut self, n: f32) {
         self.put_u32_ne(n.to_bits());
     }
@@ -1241,7 +1203,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_f64(&mut self, n: f64) {
         self.put_u64(n.to_bits());
     }
@@ -1266,7 +1227,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_f64_le(&mut self, n: f64) {
         self.put_u64_le(n.to_bits());
     }
@@ -1295,7 +1255,6 @@ pub unsafe trait BufMut {
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
     #[inline]
-    #[track_caller]
     fn put_f64_ne(&mut self, n: f64) {
         self.put_u64_ne(n.to_bits());
     }
@@ -1385,145 +1344,121 @@ pub unsafe trait BufMut {
 macro_rules! deref_forward_bufmut {
     () => {
         #[inline]
-        #[track_caller]
         fn remaining_mut(&self) -> usize {
             (**self).remaining_mut()
         }
 
         #[inline]
-        #[track_caller]
         fn chunk_mut(&mut self) -> &mut UninitSlice {
             (**self).chunk_mut()
         }
 
         #[inline]
-        #[track_caller]
         unsafe fn advance_mut(&mut self, cnt: usize) {
             (**self).advance_mut(cnt)
         }
 
         #[inline]
-        #[track_caller]
         fn put_slice(&mut self, src: &[u8]) {
             (**self).put_slice(src)
         }
 
         #[inline]
-        #[track_caller]
         fn put_u8(&mut self, n: u8) {
             (**self).put_u8(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_i8(&mut self, n: i8) {
             (**self).put_i8(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_u16(&mut self, n: u16) {
             (**self).put_u16(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_u16_le(&mut self, n: u16) {
             (**self).put_u16_le(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_u16_ne(&mut self, n: u16) {
             (**self).put_u16_ne(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_i16(&mut self, n: i16) {
             (**self).put_i16(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_i16_le(&mut self, n: i16) {
             (**self).put_i16_le(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_i16_ne(&mut self, n: i16) {
             (**self).put_i16_ne(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_u32(&mut self, n: u32) {
             (**self).put_u32(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_u32_le(&mut self, n: u32) {
             (**self).put_u32_le(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_u32_ne(&mut self, n: u32) {
             (**self).put_u32_ne(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_i32(&mut self, n: i32) {
             (**self).put_i32(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_i32_le(&mut self, n: i32) {
             (**self).put_i32_le(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_i32_ne(&mut self, n: i32) {
             (**self).put_i32_ne(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_u64(&mut self, n: u64) {
             (**self).put_u64(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_u64_le(&mut self, n: u64) {
             (**self).put_u64_le(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_u64_ne(&mut self, n: u64) {
             (**self).put_u64_ne(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_i64(&mut self, n: i64) {
             (**self).put_i64(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_i64_le(&mut self, n: i64) {
             (**self).put_i64_le(n)
         }
 
         #[inline]
-        #[track_caller]
         fn put_i64_ne(&mut self, n: i64) {
             (**self).put_i64_ne(n)
         }
@@ -1550,7 +1485,6 @@ unsafe impl BufMut for &mut [u8] {
     }
 
     #[inline]
-    #[track_caller]
     unsafe fn advance_mut(&mut self, cnt: usize) {
         if self.len() < cnt {
             panic_advance(cnt, self.len());
@@ -1562,7 +1496,6 @@ unsafe impl BufMut for &mut [u8] {
     }
 
     #[inline]
-    #[track_caller]
     fn put_slice(&mut self, src: &[u8]) {
         if self.len() < src.len() {
             panic_advance(src.len(), self.len());
@@ -1574,7 +1507,6 @@ unsafe impl BufMut for &mut [u8] {
     }
 
     #[inline]
-    #[track_caller]
     fn put_bytes(&mut self, val: u8, cnt: usize) {
         if self.len() < cnt {
             panic_advance(cnt, self.len());
@@ -1590,19 +1522,16 @@ unsafe impl BufMut for &mut [u8] {
 
 unsafe impl BufMut for &mut [core::mem::MaybeUninit<u8>] {
     #[inline]
-    #[track_caller]
     fn remaining_mut(&self) -> usize {
         self.len()
     }
 
     #[inline]
-    #[track_caller]
     fn chunk_mut(&mut self) -> &mut UninitSlice {
         UninitSlice::uninit(self)
     }
 
     #[inline]
-    #[track_caller]
     unsafe fn advance_mut(&mut self, cnt: usize) {
         if self.len() < cnt {
             panic_advance(cnt, self.len());
@@ -1614,7 +1543,6 @@ unsafe impl BufMut for &mut [core::mem::MaybeUninit<u8>] {
     }
 
     #[inline]
-    #[track_caller]
     fn put_slice(&mut self, src: &[u8]) {
         if self.len() < src.len() {
             panic_advance(src.len(), self.len());
@@ -1628,7 +1556,6 @@ unsafe impl BufMut for &mut [core::mem::MaybeUninit<u8>] {
     }
 
     #[inline]
-    #[track_caller]
     fn put_bytes(&mut self, val: u8, cnt: usize) {
         if self.len() < cnt {
             panic_advance(cnt, self.len());
@@ -1650,7 +1577,6 @@ unsafe impl BufMut for Vec<u8> {
     }
 
     #[inline]
-    #[track_caller]
     unsafe fn advance_mut(&mut self, cnt: usize) {
         let len = self.len();
         let remaining = self.capacity() - len;

--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -135,7 +135,7 @@ where
     U: Buf,
 {
     fn remaining(&self) -> usize {
-        self.a.remaining().checked_add(self.b.remaining()).unwrap()
+        self.a.remaining().saturating_add(self.b.remaining())
     }
 
     fn chunk(&self) -> &[u8] {

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -184,7 +184,7 @@ impl UninitSlice {
     /// };
     /// ```
     #[inline]
-    pub unsafe fn as_uninit_slice_mut<'a>(&'a mut self) -> &'a mut [MaybeUninit<u8>] {
+    pub unsafe fn as_uninit_slice_mut(&mut self) -> &mut [MaybeUninit<u8>] {
         &mut *(self as *mut _ as *mut [MaybeUninit<u8>])
     }
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -242,7 +242,7 @@ impl Bytes {
 
         let begin = match range.start_bound() {
             Bound::Included(&n) => n,
-            Bound::Excluded(&n) => n + 1,
+            Bound::Excluded(&n) => n.checked_add(1).expect("out of range"),
             Bound::Unbounded => 0,
         };
 

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1086,7 +1086,6 @@ unsafe impl BufMut for BytesMut {
     }
 
     #[inline]
-    #[track_caller]
     unsafe fn advance_mut(&mut self, cnt: usize) {
         let remaining = self.cap - self.len();
         if cnt > remaining {

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1086,15 +1086,14 @@ unsafe impl BufMut for BytesMut {
     }
 
     #[inline]
+    #[track_caller]
     unsafe fn advance_mut(&mut self, cnt: usize) {
-        let new_len = self.len() + cnt;
-        assert!(
-            new_len <= self.cap,
-            "new_len = {}; capacity = {}",
-            new_len,
-            self.cap
-        );
-        self.len = new_len;
+        let remaining = self.cap - self.len();
+        if cnt > remaining {
+            panic_advance(cnt, remaining);
+        }
+        // Addition won't overflow since it is at most `self.cap`.
+        self.len = self.len() + cnt;
     }
 
     #[inline]

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1090,7 +1090,7 @@ unsafe impl BufMut for BytesMut {
     unsafe fn advance_mut(&mut self, cnt: usize) {
         let remaining = self.cap - self.len();
         if cnt > remaining {
-            panic_advance(cnt, remaining);
+            super::panic_advance(cnt, remaining);
         }
         // Addition won't overflow since it is at most `self.cap`.
         self.len = self.len() + cnt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,3 +115,34 @@ fn abort() -> ! {
         panic!("abort");
     }
 }
+
+#[inline(always)]
+fn saturating_sub_usize_u64(a: usize, b: u64) -> usize {
+    use core::convert::TryFrom;
+    match usize::try_from(b) {
+        Ok(b) => a.saturating_sub(b),
+        Err(_) => 0,
+    }
+}
+
+#[inline(always)]
+fn min_u64_usize(a: u64, b: usize) -> usize {
+    use core::convert::TryFrom;
+    match usize::try_from(a) {
+        Ok(a) => usize::min(a, b),
+        Err(_) => b,
+    }
+}
+
+/// Panic with a nice error message.
+#[cold]
+#[track_caller]
+fn panic_advance(idx: usize, len: usize) -> ! {
+    panic!("advance out of bounds: the len is {} but advancing by {}", len, idx);
+}
+
+#[cold]
+#[track_caller]
+fn panic_does_not_fit(size: usize, nbytes: usize) -> ! {
+    panic!("size too large: the integer type can fit {} bytes, but nbytes is {}", size, nbytes);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,11 +138,17 @@ fn min_u64_usize(a: u64, b: usize) -> usize {
 #[cold]
 #[track_caller]
 fn panic_advance(idx: usize, len: usize) -> ! {
-    panic!("advance out of bounds: the len is {} but advancing by {}", len, idx);
+    panic!(
+        "advance out of bounds: the len is {} but advancing by {}",
+        len, idx
+    );
 }
 
 #[cold]
 #[track_caller]
 fn panic_does_not_fit(size: usize, nbytes: usize) -> ! {
-    panic!("size too large: the integer type can fit {} bytes, but nbytes is {}", size, nbytes);
+    panic!(
+        "size too large: the integer type can fit {} bytes, but nbytes is {}",
+        size, nbytes
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,6 @@ fn min_u64_usize(a: u64, b: usize) -> usize {
 
 /// Panic with a nice error message.
 #[cold]
-#[track_caller]
 fn panic_advance(idx: usize, len: usize) -> ! {
     panic!(
         "advance out of bounds: the len is {} but advancing by {}",
@@ -147,7 +146,6 @@ fn panic_advance(idx: usize, len: usize) -> ! {
 }
 
 #[cold]
-#[track_caller]
 fn panic_does_not_fit(size: usize, nbytes: usize) -> ! {
     panic!(
         "size too large: the integer type can fit {} bytes, but nbytes is {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ fn abort() -> ! {
 }
 
 #[inline(always)]
+#[cfg(feature = "std")]
 fn saturating_sub_usize_u64(a: usize, b: u64) -> usize {
     use core::convert::TryFrom;
     match usize::try_from(b) {
@@ -126,6 +127,7 @@ fn saturating_sub_usize_u64(a: usize, b: u64) -> usize {
 }
 
 #[inline(always)]
+#[cfg(feature = "std")]
 fn min_u64_usize(a: u64, b: usize) -> usize {
     use core::convert::TryFrom;
     match usize::try_from(a) {

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -83,7 +83,7 @@ fn test_put_int_le_nbytes_overflow() {
 }
 
 #[test]
-#[should_panic(expected = "cannot advance")]
+#[should_panic(expected = "advance out of bounds: the len is 8 but advancing by 12")]
 fn test_vec_advance_mut() {
     // Verify fix for #354
     let mut buf = Vec::with_capacity(8);


### PR DESCRIPTION
This performs various cleanup:

 * Factor a lot of panics into functions to improve error messages and reduce codegen.
 * Add missing `#[inline]` ~~and `#[track_caller]`~~.
 * Fix some arithmetic overflows in bounds checks.