### PR TITLE
remove deprecated primitive type

### DIFF
--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -1573,7 +1573,7 @@ unsafe impl BufMut for Vec<u8> {
     #[inline]
     fn remaining_mut(&self) -> usize {
         // A vector can never have more than isize::MAX bytes
-       isize::MAX as usize - self.len()
+        isize::MAX as usize - self.len()
     }
 
     #[inline]

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -3,7 +3,7 @@ use crate::buf::{limit, Chain, Limit, UninitSlice};
 use crate::buf::{writer, Writer};
 use crate::{panic_advance, panic_does_not_fit};
 
-use core::{mem, ptr, usize};
+use core::{mem, ptr};
 
 use alloc::{boxed::Box, vec::Vec};
 
@@ -1573,7 +1573,7 @@ unsafe impl BufMut for Vec<u8> {
     #[inline]
     fn remaining_mut(&self) -> usize {
         // A vector can never have more than isize::MAX bytes
-        core::isize::MAX as usize - self.len()
+       isize::MAX as usize - self.len()
     }
 
     #[inline]

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,6 +1,6 @@
 use core::iter::FromIterator;
 use core::ops::{Deref, RangeBounds};
-use core::{cmp, fmt, hash, mem, ptr, slice, usize};
+use core::{cmp, fmt, hash, mem, ptr, slice};
 
 use alloc::{
     alloc::{dealloc, Layout},

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -2,7 +2,7 @@ use core::iter::{FromIterator, Iterator};
 use core::mem::{self, ManuallyDrop, MaybeUninit};
 use core::ops::{Deref, DerefMut};
 use core::ptr::{self, NonNull};
-use core::{cmp, fmt, hash, isize, slice, usize};
+use core::{cmp, fmt, hash, slice};
 
 use alloc::{
     borrow::{Borrow, BorrowMut},

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -4,7 +4,6 @@ use bytes::buf::UninitSlice;
 use bytes::{BufMut, BytesMut};
 use core::fmt::Write;
 use core::mem::MaybeUninit;
-use core::usize;
 
 #[test]
 fn test_vec_as_mut_buf() {

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -2,8 +2,6 @@
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-use std::usize;
-
 const LONG: &[u8] = b"mary had a little lamb, little lamb, little lamb";
 const SHORT: &[u8] = b"hello world";
 


### PR DESCRIPTION
Since primitive types defined at https://github.com/rust-lang/rust/tree/4331c151b09a065f6b3bedf4158edc336317bc0d/library/core/src/num/shells are going to be deprecated and will be replaced by types defined at https://github.com/rust-lang/rust/blob/4331c151b09a065f6b3bedf4158edc336317bc0d/library/core/src/num/mod.rs which has been stable since `1.0.0`, It seems a good time to update the corresponding implementations to align with these changes