### PR TITLE
docs: fix broken links

### DIFF
--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -25,9 +25,7 @@ use std::io::IoSlice;
 /// assert_eq!(full[..], b"hello world"[..]);
 /// ```
 ///
-/// [`Buf::chain`]: trait.Buf.html#method.chain
-/// [`Buf`]: trait.Buf.html
-/// [`BufMut`]: trait.BufMut.html
+/// [`Buf::chain`]: Buf::chain
 #[derive(Debug)]
 pub struct Chain<T, U> {
     a: T,

--- a/src/buf/iter.rs
+++ b/src/buf/iter.rs
@@ -17,9 +17,6 @@ use crate::Buf;
 /// assert_eq!(iter.next(), Some(b'c'));
 /// assert_eq!(iter.next(), None);
 /// ```
-///
-/// [`iter`]: trait.Buf.html#method.iter
-/// [`Buf`]: trait.Buf.html
 #[derive(Debug)]
 pub struct IntoIter<T> {
     inner: T,

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -13,8 +13,6 @@
 //! See [`Buf`] and [`BufMut`] for more details.
 //!
 //! [rope]: https://en.wikipedia.org/wiki/Rope_(data_structure)
-//! [`Buf`]: trait.Buf.html
-//! [`BufMut`]: trait.BufMut.html
 
 mod buf_impl;
 mod buf_mut;

--- a/src/buf/reader.rs
+++ b/src/buf/reader.rs
@@ -5,7 +5,7 @@ use std::{cmp, io};
 /// A `Buf` adapter which implements `io::Read` for the inner value.
 ///
 /// This struct is generally created by calling `reader()` on `Buf`. See
-/// documentation of [`reader()`](trait.Buf.html#method.reader) for more
+/// documentation of [`reader()`](Buf::reader) for more
 /// details.
 #[derive(Debug)]
 pub struct Reader<B> {

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -5,7 +5,7 @@ use core::cmp;
 /// A `Buf` adapter which limits the bytes read from an underlying buffer.
 ///
 /// This struct is generally created by calling `take()` on `Buf`. See
-/// documentation of [`take()`](trait.Buf.html#method.take) for more details.
+/// documentation of [`take()`](Buf::take) for more details.
 #[derive(Debug)]
 pub struct Take<T> {
     inner: T,

--- a/src/buf/writer.rs
+++ b/src/buf/writer.rs
@@ -5,7 +5,7 @@ use std::{cmp, io};
 /// A `BufMut` adapter which implements `io::Write` for the inner value.
 ///
 /// This struct is generally created by calling `writer()` on `BufMut`. See
-/// documentation of [`writer()`](trait.BufMut.html#method.writer) for more
+/// documentation of [`writer()`](BufMut::writer) for more
 /// details.
 #[derive(Debug)]
 pub struct Writer<B> {

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -438,7 +438,7 @@ impl Bytes {
     /// If `len` is greater than the buffer's current length, this has no
     /// effect.
     ///
-    /// The [`split_off`] method can emulate `truncate`, but this causes the
+    /// The [split_off](`Self::split_off()`) method can emulate `truncate`, but this causes the
     /// excess bytes to be returned instead of dropped.
     ///
     /// # Examples
@@ -450,8 +450,6 @@ impl Bytes {
     /// buf.truncate(5);
     /// assert_eq!(buf, b"hello"[..]);
     /// ```
-    ///
-    /// [`split_off`]: #method.split_off
     #[inline]
     pub fn truncate(&mut self, len: usize) {
         if len < self.len {

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -399,7 +399,7 @@ impl BytesMut {
     ///
     /// Existing underlying capacity is preserved.
     ///
-    /// The [`split_off`] method can emulate `truncate`, but this causes the
+    /// The [split_off](`Self::split_off()`) method can emulate `truncate`, but this causes the
     /// excess bytes to be returned instead of dropped.
     ///
     /// # Examples
@@ -411,8 +411,6 @@ impl BytesMut {
     /// buf.truncate(5);
     /// assert_eq!(buf, b"hello"[..]);
     /// ```
-    ///
-    /// [`split_off`]: #method.split_off
     pub fn truncate(&mut self, len: usize) {
         if len <= self.len() {
             unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,8 @@
 //! Provides abstractions for working with bytes.
 //!
 //! The `bytes` crate provides an efficient byte buffer structure
-//! ([`Bytes`](struct.Bytes.html)) and traits for working with buffer
+//! ([`Bytes`]) and traits for working with buffer
 //! implementations ([`Buf`], [`BufMut`]).
-//!
-//! [`Buf`]: trait.Buf.html
-//! [`BufMut`]: trait.BufMut.html
 //!
 //! # `Bytes`
 //!
@@ -52,9 +49,7 @@
 //! `a` and `b` will share the underlying buffer and maintain indices tracking
 //! the view into the buffer represented by the handle.
 //!
-//! See the [struct docs] for more details.
-//!
-//! [struct docs]: struct.Bytes.html
+//! See the [struct docs](`Bytes`) for more details.
 //!
 //! # `Buf`, `BufMut`
 //!
@@ -70,7 +65,7 @@
 //! ## Relation with `Read` and `Write`
 //!
 //! At first glance, it may seem that `Buf` and `BufMut` overlap in
-//! functionality with `std::io::Read` and `std::io::Write`. However, they
+//! functionality with [`std::io::Read`] and [`std::io::Write`]. However, they
 //! serve different purposes. A buffer is the value that is provided as an
 //! argument to `Read::read` and `Write::write`. `Read` and `Write` may then
 //! perform a syscall, which has the potential of failing. Operations on `Buf`


### PR DESCRIPTION
Fixed a few broken links and converted a lot of them from the html-link to intra-doc links.