### PR TITLE
add `Bytes::is_unique`

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -214,17 +214,21 @@ impl Bytes {
     ///
     /// Always returns false if the data is backed by a static slice.
     ///
+    /// The result of this method may be invalidated immediately if another
+    /// thread clones this value while this is being called. Ensure you have
+    /// unique access to this value (`&mut Bytes`) first if you need to be
+    /// certain the result is valid (i.e. for safety reasons)
     /// # Examples
     ///
     /// ```
     /// use bytes::Bytes;
     ///
-    /// let mut a = Bytes::from(vec![1, 2, 3]);
+    /// let a = Bytes::from(vec![1, 2, 3]);
     /// assert!(a.is_unique());
     /// let b = a.clone();
     /// assert!(!a.is_unique());
     /// ```
-    pub fn is_unique(&mut self) -> bool {
+    pub fn is_unique(&self) -> bool {
         unsafe { (self.vtable.is_unique)(&self.data) }
     }
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -217,12 +217,12 @@ impl Bytes {
     /// ```
     /// use bytes::Bytes;
     ///
-    /// let a = Bytes::from(vec![1, 2, 3]);
+    /// let mut a = Bytes::from(vec![1, 2, 3]);
     /// assert!(a.is_unique());
     /// let b = a.clone();
     /// assert!(!a.is_unique());
     /// ```
-    pub fn is_unique(&self) -> bool {
+    pub fn is_unique(&mut self) -> bool {
         if core::ptr::eq(self.vtable, &PROMOTABLE_EVEN_VTABLE)
             || core::ptr::eq(self.vtable, &PROMOTABLE_ODD_VTABLE)
         {

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1702,6 +1702,7 @@ unsafe fn rebuild_vec(ptr: *mut u8, mut len: usize, mut cap: usize, off: usize) 
 static SHARED_VTABLE: Vtable = Vtable {
     clone: shared_v_clone,
     to_vec: shared_v_to_vec,
+    is_unique: crate::bytes::shared_is_unique,
     drop: shared_v_drop,
 };
 

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1208,3 +1208,36 @@ fn test_bytes_capacity_len() {
         }
     }
 }
+
+#[test]
+fn static_is_unique() {
+    let b = Bytes::from_static(LONG);
+    assert!(!b.is_unique());
+}
+
+#[test]
+fn vec_is_unique() {
+    let v: Vec<u8> = LONG.to_vec();
+    let b = Bytes::from(v);
+    assert!(b.is_unique());
+}
+
+#[test]
+fn arc_is_unique() {
+    let v: Vec<u8> = LONG.to_vec();
+    let b = Bytes::from(v);
+    let c = b.clone();
+    assert!(!b.is_unique());
+    drop(c);
+    assert!(b.is_unique());
+}
+
+#[test]
+fn shared_is_unique() {
+    let v: Vec<u8> = LONG.to_vec();
+    let b = Bytes::from(v);
+    let c = b.clone();
+    assert!(!c.is_unique());
+    drop(b);
+    assert!(c.is_unique());
+}


### PR DESCRIPTION
Closes #533

This adds the `is_unique` method to `Bytes`. It checks reference count when backed by (effectively) `Arc<Vec<u8>>`, returns true when backed by a vec, and returns false for static slices