### PR TITLE
uninit_slice: simplify as_uninit_slice_mut() logic

### DIFF
--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -185,7 +185,7 @@ impl UninitSlice {
     /// ```
     #[inline]
     pub unsafe fn as_uninit_slice_mut(&mut self) -> &mut [MaybeUninit<u8>] {
-        &mut *(self as *mut _ as *mut [MaybeUninit<u8>])
+        &mut self.0
     }
 
     /// Returns the number of bytes in the slice.


### PR DESCRIPTION
This reworks `UninitSlice::as_uninit_slice_mut()` using equivalent simpler logic.