### PR TITLE
BytesMut: Assert alignment of Shared

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -80,6 +80,12 @@ struct Shared {
     ref_count: AtomicUsize,
 }
 
+// Assert that the alignment of `Shared` is divisible by 2.
+// This is a necessary invariant since we depend on allocating `Shared` a
+// shared object to implicitly carry the `KIND_ARC` flag in its pointer.
+// This flag is set when the LSB is 0.
+const _: [(); 0 - mem::align_of::<Shared>() % 2] = []; // Assert that the alignment of `Shared` is divisible by 2.
+
 // Buffer storage strategy flags.
 const KIND_ARC: usize = 0b0;
 const KIND_VEC: usize = 0b1;


### PR DESCRIPTION
Back in #362, an assertion was added to ensure that the alignment of `bytes::Shared` is even so we can use the least significant bit as a flag. `bytes_mut::Shared` uses the same technique but has no such assertion so I've added one here.