### PR TITLE
Add support for the nightly unstable allocator API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ categories = ["network-programming", "data-structures"]
 [features]
 default = ["std"]
 std = []
+allocator_api = []
 
 [dependencies]
 serde = { version = "1.0.60", optional = true, default-features = false, features = ["alloc"] }

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -1389,7 +1389,13 @@ impl<T: Buf + ?Sized> Buf for &mut T {
     deref_forward_buf!();
 }
 
+#[cfg(not(feature = "allocator_api"))]
 impl<T: Buf + ?Sized> Buf for Box<T> {
+    deref_forward_buf!();
+}
+
+#[cfg(feature = "allocator_api")]
+impl<T: Buf + ?Sized, A: core::alloc::Allocator> Buf for Box<T, A> {
     deref_forward_buf!();
 }
 

--- a/src/buf/macros.rs
+++ b/src/buf/macros.rs
@@ -1,0 +1,22 @@
+/// impl_with_allocator implements a specified trait for a concrete type that
+/// is expected to take some number of generic arguments and optionally a
+/// trailing allocator argument of type [core::alloc::Allocator] only if the
+/// unstable `allocator_api` feature is enabled.
+#[macro_export]
+macro_rules! impl_with_allocator {
+    { impl $interface:ident for $concrete:ident<$( $generic_args:ty ),*> $implementation:tt } => {
+        #[cfg(not(feature = "allocator_api"))]
+        impl $interface for $concrete<$( $generic_args ),*> $implementation
+
+        #[cfg(feature = "allocator_api")]
+        impl<A: core::alloc::Allocator> $interface for $concrete<$( $generic_args ),*, A> $implementation
+    };
+
+    { unsafe impl $interface:ident for $concrete:ident<$( $generic_args:ty ),*> $implementation:tt } => {
+        #[cfg(not(feature = "allocator_api"))]
+        unsafe impl $interface for $concrete<$( $generic_args ),*> $implementation
+
+        #[cfg(feature = "allocator_api")]
+        unsafe impl<A: core::alloc::Allocator> $interface for $concrete<$( $generic_args ),*, A> $implementation
+    };
+}

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -19,6 +19,7 @@ mod buf_mut;
 mod chain;
 mod iter;
 mod limit;
+mod macros;
 #[cfg(feature = "std")]
 mod reader;
 mod take;

--- a/src/buf/vec_deque.rs
+++ b/src/buf/vec_deque.rs
@@ -1,22 +1,25 @@
+use crate::impl_with_allocator;
 use alloc::collections::VecDeque;
 
 use super::Buf;
 
-impl Buf for VecDeque<u8> {
-    fn remaining(&self) -> usize {
-        self.len()
-    }
-
-    fn chunk(&self) -> &[u8] {
-        let (s1, s2) = self.as_slices();
-        if s1.is_empty() {
-            s2
-        } else {
-            s1
+impl_with_allocator! {
+    impl Buf for VecDeque<u8> {
+        fn remaining(&self) -> usize {
+            self.len()
         }
-    }
 
-    fn advance(&mut self, cnt: usize) {
-        self.drain(..cnt);
+        fn chunk(&self) -> &[u8] {
+            let (s1, s2) = self.as_slices();
+            if s1.is_empty() {
+                s2
+            } else {
+                s1
+            }
+        }
+
+        fn advance(&mut self, cnt: usize) {
+            self.drain(..cnt);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
 #![no_std]
+#![cfg_attr(feature = "allocator_api", feature(allocator_api))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Provides abstractions for working with bytes.


### PR DESCRIPTION
Fixes #653.

Adds a new, optional feature to the `bytes` crate to enable support for the Rust nightly unstable `allocator_api` feature ([docs](https://doc.rust-lang.org/beta/unstable-book/library-features/allocator-api.html)).

This feature is disabled by default and will only work on Rust nightly for now.

When enabled, this feature changes the default implementations of `Buf` and `BufMut` on `Box<u8>`, `Vec<u8>`, and `VecDeque<u8>` to support an optional second generic argument for an `Allocator` type. This `Allocator` controls how the type manages memory on the heap. No code paths are changed in the crate, only a new generic argument is provided to these types.

When disabled, this feature incurs no changes to the crate and does not change the API or any code paths.