### PR TITLE
Add SeekBuf trait and BufCursor implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ categories = ["network-programming", "data-structures"]
 [features]
 default = ["std"]
 std = []
+iter_advance_by = []
 
 [dependencies]
 serde = { version = "1.0.60", optional = true, default-features = false, features = ["alloc"] }

--- a/src/buf/cursor.rs
+++ b/src/buf/cursor.rs
@@ -1,0 +1,352 @@
+use crate::Buf;
+use crate::buf::SeekBuf;
+
+use core::iter::FusedIterator;
+use core::cell::Cell;
+use core::num::NonZeroUsize;
+use core::ops::{Bound, RangeBounds};
+
+/// Provides a non-mutating view of the bytes in a buffer.
+///
+/// [BufCursor] implements [Iterator] for `&u8` items, and provides
+/// compatibility for the full suite of compatible iterator helpers for any
+/// buffers that support arbitrary position reads via [SeekBuf].
+///
+/// A cursor closely resembles a buffer itself; in fact, it also implements
+/// [Buf] and [SeekBuf] like its parent. This also makes recursive cursor
+/// instantiation possible, so sub-cursors can be consumed without mutating
+/// the original cursor or original buffer.
+///
+/// [BufCursor] aims for optimal performance even for buffers which may
+/// introduce latency for retrieving chunks (such as `dyn SeekBuf` buffers). It
+/// stores the most recently retrieved chunk for subsequent access up to the
+/// length of that chunk, amortizing the cost of any buffer retrieval calls
+/// across the size of all returned chunks.
+#[derive(Debug)]
+pub struct BufCursor<'b, B: SeekBuf + ?Sized> {
+    buf: &'b B,
+    front_chunk_offset: Cell<usize>,
+    back_chunk_offset: Cell<usize>,
+    front_chunk: Cell<Option<&'b [u8]>>,
+    back_chunk: Cell<Option<&'b [u8]>>,
+}
+
+impl<'b, B: SeekBuf + ?Sized> BufCursor<'b, B> {
+    /// Creates a new [BufCursor] starting at the beginning of the provided
+    /// buffer and ending at the end of the buffer, as determined by the length
+    /// provided by [Buf::remaining].
+    pub fn new(buf: &'b B) -> Self {
+        Self {
+            buf,
+            front_chunk_offset: Cell::new(0),
+            back_chunk_offset: Cell::new(buf.remaining()),
+            front_chunk: Cell::new(None),
+            back_chunk: Cell::new(None),
+        }
+    }
+
+    /// Returns the offset of the original buffer that the cursor's front is
+    /// currently set to read.
+    ///
+    /// This offset is zero-indexed from the beginning of the buffer.
+    ///
+    /// # Notes
+    ///
+    /// This method may allow callers to understand the layout of the underlying
+    /// buffer while only provided with a sub-cursor.
+    #[inline]
+    pub fn front_offset(&self) -> usize {
+        self.front_chunk_offset.get() - self.front_chunk_len()
+    }
+
+
+    /// Returns the offset of the original buffer that the cursor's back is
+    /// currently set to read.
+    ///
+    /// This offset is zero-indexed from the beginning of the buffer.
+    ///
+    /// # Notes
+    ///
+    /// This method may allow callers to understand the layout of the underlying
+    /// buffer while only provided with a sub-cursor.
+    #[inline]
+    pub fn back_offset(&self) -> usize {
+        self.back_chunk_offset.get() + self.back_chunk_len()
+    }
+
+    /// Moves the cursor to the range specified and returns a new cursor at the
+    /// respective front and back offsets, consuming itself in the process.
+    ///
+    /// If the range provided moves the cursor out of its supported range,
+    /// then [None] is returned and the cursor (`self`) is destroyed.
+    ///
+    /// Should the current cursor need to remain valid after the call to
+    /// [Self::seek], call [Self::cursor] first to create a new sub-cursor at
+    /// the current cursor position, then call [Self::seek] on the new
+    /// sub-cursor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::SeekBuf;
+    ///
+    /// let buf = b"<<< TEXT >>>".as_slice();
+    ///
+    /// let cursor = buf.cursor().seek(4..8).unwrap();
+    ///
+    /// let bytes = cursor.copied().collect::<Vec<u8>>();
+    ///
+    /// assert_eq!(bytes.as_slice(), b"TEXT".as_slice())
+    /// ```
+    pub fn seek<R: RangeBounds<usize>>(self, range: R) -> Option<Self> {
+        let remaining = self.remaining();
+
+        let relative_front_offset = match range.start_bound() {
+            Bound::Included(start_inclusive) => *start_inclusive,
+            // Exclusive range start bounds are unimplemented in Rust 2023,
+            // but my be implemented in the future. This line may be uncovered.
+            Bound::Excluded(start_exclusive) => *start_exclusive + 1,
+            Bound::Unbounded => 0,
+        };
+
+        let relative_back_offset = match range.end_bound() {
+            Bound::Included(end_inclusive) => *end_inclusive + 1,
+            Bound::Excluded(end_exclusive) => *end_exclusive,
+            Bound::Unbounded => remaining,
+        };
+
+        if relative_front_offset > relative_back_offset || relative_back_offset > remaining {
+            return None;
+        }
+
+        let absolute_offset = self.front_offset();
+
+        let front_chunk_offset = absolute_offset + relative_front_offset;
+        let back_chunk_offset = absolute_offset + relative_back_offset;
+
+        Some(Self {
+            buf: self.buf,
+            front_chunk_offset: Cell::new(front_chunk_offset),
+            back_chunk_offset: Cell::new(back_chunk_offset),
+            front_chunk: Cell::new(None),
+            back_chunk: Cell::new(None),
+        })
+    }
+}
+
+impl<'b, B: SeekBuf + ?Sized> BufCursor<'b, B> {
+    #[inline]
+    fn front_chunk_len(&self) -> usize {
+        self.front_chunk.get().map_or(0, |chunk| chunk.len())
+    }
+
+    #[inline]
+    fn back_chunk_len(&self) -> usize {
+        self.back_chunk.get().map_or(0, |chunk| chunk.len())
+    }
+
+    fn next_front_chunk(&self) -> Option<&'b [u8]> {
+        match self.front_chunk.get() {
+            Some(chunk) if !chunk.is_empty() => Some(chunk),
+            _ => {
+                let chunk = self.buf.chunk_from(self.front_chunk_offset.get())?;
+                self.front_chunk.set(Some(chunk));
+                self.front_chunk_offset
+                    .set(self.front_chunk_offset.get() + chunk.len());
+                Some(chunk)
+            }
+        }
+    }
+
+    fn next_back_chunk(&self) -> Option<&'b [u8]> {
+        match self.back_chunk.get() {
+            Some(chunk) if !chunk.is_empty() => Some(chunk),
+            _ => {
+                let chunk = self.buf.chunk_to(self.back_chunk_offset.get())?;
+                self.back_chunk.set(Some(chunk));
+                self.back_chunk_offset
+                    .set(self.back_chunk_offset.get() - chunk.len());
+                Some(chunk)
+            }
+        }
+    }
+
+    #[allow(unused)]
+    fn advance_front_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
+        let chunk_len = if let Some(chunk) = self.front_chunk.get() {
+            let chunk_len = chunk.len();
+
+            if n < chunk_len {
+                self.front_chunk.set(Some(&chunk[n..]));
+                return Ok(());
+            }
+
+            chunk_len
+        } else {
+            0
+        };
+
+        let remaining = self.remaining();
+
+        if n < remaining {
+            self.front_chunk_offset
+                .set(self.front_chunk_offset.get() + n - chunk_len);
+            self.front_chunk
+                .set(self.buf.chunk_from(self.front_chunk_offset.get()));
+            Ok(())
+        } else {
+            self.front_chunk_offset
+                .set(self.front_chunk_offset.get() + remaining);
+            self.front_chunk.set(None);
+
+            match NonZeroUsize::new(n - remaining) {
+                None => Ok(()),
+                Some(n_remaining) => Err(n_remaining),
+            }
+        }
+    }
+
+    #[allow(unused)]
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
+        let chunk_len = if let Some(chunk) = self.back_chunk.get() {
+            let chunk_len = chunk.len();
+
+            if n < chunk_len {
+                self.back_chunk.set(Some(&chunk[..chunk_len - n]));
+                return Ok(());
+            }
+
+            chunk_len
+        } else {
+            0
+        };
+
+        let remaining = self.remaining();
+
+        if n < remaining {
+            self.back_chunk_offset
+                .set(self.back_chunk_offset.get() - n - chunk_len);
+            self.back_chunk
+                .set(self.buf.chunk_from(self.back_chunk_offset.get()));
+            Ok(())
+        } else {
+            self.back_chunk_offset
+                .set(self.back_chunk_offset.get() - remaining);
+            self.back_chunk.set(None);
+
+            match NonZeroUsize::new(n - remaining) {
+                None => Ok(()),
+                Some(n_remaining) => Err(n_remaining),
+            }
+        }
+    }
+}
+
+impl<'b, B: SeekBuf + ?Sized> Buf for BufCursor<'b, B> {
+    #[inline]
+    fn remaining(&self) -> usize {
+        self.back_offset() - self.front_offset()
+    }
+
+    #[inline]
+    fn chunk(&self) -> &[u8] {
+        self.next_front_chunk().unwrap_or(&[])
+    }
+
+    #[inline]
+    fn advance(&mut self, cnt: usize) {
+        self.advance_front_by(cnt).unwrap()
+    }
+}
+
+impl<'b, B: SeekBuf + ?Sized> SeekBuf for BufCursor<'b, B> {
+    fn chunk_from(&self, start: usize) -> Option<&[u8]> {
+        let remaining = self.remaining();
+        if start >= remaining {
+            return None;
+        }
+
+        let chunk = self.buf.chunk_from(self.front_offset() + start)?;
+
+        Some(&chunk[..chunk.len().min(remaining - start)])
+    }
+
+    fn chunk_to(&self, end: usize) -> Option<&[u8]> {
+        let remaining = self.remaining();
+        if end > remaining {
+            return None;
+        }
+
+        let chunk = self.buf.chunk_to(self.back_offset() - end)?;
+
+        Some(&chunk[(remaining - end).min(chunk.len())..])
+    }
+}
+
+impl<'b, B: SeekBuf + ?Sized> Iterator for BufCursor<'b, B> {
+    type Item = &'b u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let remaining = self.remaining();
+
+        if remaining == 0 {
+            return None;
+        }
+
+        let chunk = self.next_front_chunk()?;
+
+        let (next, front_chunk) = match chunk.len() {
+            // Most SeekBuf implementations will not need this line, but should
+            // an implementation return an empty slice chunk instead of None,
+            // this match case (chunk length of zero) may be hit.
+            0 => (None, None),
+            1 => (Some(&chunk[0]), None),
+            _ => (Some(&chunk[0]), Some(&chunk[1..])),
+        };
+
+        self.front_chunk.set(front_chunk);
+
+        next
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining(), Some(self.remaining()))
+    }
+
+    #[cfg(feature = "iter_advance_by")]
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
+        self.advance_front_by(n)
+    }
+}
+
+impl<'b, B: SeekBuf + ?Sized> DoubleEndedIterator for BufCursor<'b, B> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.remaining() == 0 {
+            return None;
+        }
+
+        let chunk = self.next_back_chunk()?;
+
+        let (next, back_chunk) = match chunk.len() {
+            // Most SeekBuf implementations will not need this line, but should
+            // an implementation return an empty slice chunk instead of None,
+            // this match case (chunk length of zero) may be hit.
+            0 => (None, None),
+            1 => (Some(&chunk[0]), None),
+            len => (Some(&chunk[len - 1]), Some(&chunk[..len - 1])),
+        };
+
+        self.back_chunk.set(back_chunk);
+
+        next
+    }
+
+    #[cfg(feature = "iter_advance_by")]
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
+        self.advance_back_by(n)
+    }
+}
+
+impl<'b, B: SeekBuf + ?Sized> FusedIterator for BufCursor<'b, B> {}
+
+impl<'b, B: SeekBuf + ?Sized> ExactSizeIterator for BufCursor<'b, B> {}

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -17,10 +17,12 @@
 mod buf_impl;
 mod buf_mut;
 mod chain;
+mod cursor;
 mod iter;
 mod limit;
 #[cfg(feature = "std")]
 mod reader;
+mod seek_buf;
 mod take;
 mod uninit_slice;
 mod vec_deque;
@@ -30,8 +32,10 @@ mod writer;
 pub use self::buf_impl::Buf;
 pub use self::buf_mut::BufMut;
 pub use self::chain::Chain;
+pub use self::cursor::BufCursor;
 pub use self::iter::IntoIter;
 pub use self::limit::Limit;
+pub use self::seek_buf::SeekBuf;
 pub use self::take::Take;
 pub use self::uninit_slice::UninitSlice;
 

--- a/src/buf/seek_buf.rs
+++ b/src/buf/seek_buf.rs
@@ -1,0 +1,192 @@
+use crate::Buf;
+
+use core::ops::DerefMut;
+use core::pin::Pin;
+
+use alloc::boxed::Box;
+use crate::buf::cursor::BufCursor;
+
+/// Read bytes from an arbitrary position within a buffer.
+///
+/// This is an extension over the standard [Buf] type that allows seeking to
+/// arbitrary positions within the buffer for reads. The buffer may return
+/// chunks of bytes at each position of undetermined length, to allow for
+/// buffer implementations that are formed using non-contiguous memory.
+///
+/// It is always true that a [SeekBuf] is also a [Buf], but not always the
+/// inverse.
+///
+/// Many types that implement [Buf] may also implement [SeekBuf], including:
+///     - `&[u8]`
+///     - [alloc::collections::VecDeque]
+///
+/// # Examples
+///
+/// ```
+/// use bytes::{Buf, SeekBuf};
+///
+/// let buf = b"try to find the T in the haystack".as_slice();
+///
+/// let remaining = buf.remaining();
+///
+/// assert!(buf.cursor().find(|&&b| b == b'Q').is_none());
+/// assert!(buf.cursor().find(|&&b| b == b'T').is_some());
+///
+/// // No bytes in the buffer were consumed while using the cursor.
+/// assert_eq!(remaining, buf.remaining());
+/// ```
+pub trait SeekBuf: Buf {
+    /// Returns a chunk of unspecified length (but not exceeding
+    /// [Self::remaining]) starting at the specified inclusive index position.
+    ///
+    /// This method can be alternately thought of as equivalent to the
+    /// `[start..]` range indexing operation.
+    ///
+    /// # Implementer notes
+    ///
+    /// Implementations of [Self::chunk_from] should return [None] if the
+    /// `start` index is out of range for optimal performance. Implementations
+    /// that return values of empty slices are functionally equivalent, but may
+    /// hit slower code paths during use.
+    ///
+    /// Note that the `end` argument is an **inclusive** bound.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::SeekBuf;
+    ///
+    /// let buf = b"hello world".as_slice();
+    ///
+    /// assert_eq!(buf.chunk_from(6), Some(b"world".as_slice()));
+    /// assert_eq!(buf.chunk_from(100), None);
+    /// ```
+    fn chunk_from(&self, start: usize) -> Option<&[u8]>;
+
+    /// Returns a chunk of unspecified length (but not exceeding
+    /// [Self::remaining]) ending at the specified exclusive index position.
+    ///
+    /// This method can be alternately thought of as equivalent to the
+    /// `[..end]` range indexing operation.
+    ///
+    /// # Implementer notes
+    ///
+    /// Implementations of [Self::chunk_to] should return [None] if the `end`
+    /// index is out of range for optimal performance. Implementations that
+    /// return values of empty slices are functionally equivalent, but may hit
+    /// slower code paths during use.
+    ///
+    /// An identity of this function is that any call with an `end` argument of
+    /// zero will unconditionally return `Some(&[])`, rather than `None`, since
+    /// a sub-slice of zero length is a valid chunk of any buffer of any length.
+    ///
+    /// Note that the `end` argument is an **exclusive** bound.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::SeekBuf;
+    ///
+    /// let buf = b"hello world".as_slice();
+    ///
+    /// assert_eq!(buf.chunk_to(5), Some(b"hello".as_slice()));
+    /// assert_eq!(buf.chunk_to(100), None);
+    ///
+    /// // It may not be intuitive, but an identity of `chunk_to` is that when
+    /// // passed an `end` of zero, it will always return an empty slice instead
+    /// // of `None`.
+    /// assert_eq!([].as_slice().chunk_to(0), Some([].as_slice()));
+    /// ```
+    fn chunk_to(&self, end: usize) -> Option<&[u8]>;
+
+    /// Returns a new [BufCursor] that can iterate over the current buffer.
+    /// [Self] is borrowed immutably while the cursor is active.
+    ///
+    /// ```
+    /// use bytes::SeekBuf;
+    ///
+    /// let buf = b"hello world".as_slice();
+    ///
+    /// let mut cursor = buf.cursor();
+    ///
+    /// assert_eq!(cursor.next(), Some(&b'h'));
+    /// assert_eq!(cursor.next(), Some(&b'e'));
+    /// assert_eq!(cursor.next(), Some(&b'l'));
+    /// assert_eq!(cursor.next(), Some(&b'l'));
+    /// assert_eq!(cursor.next(), Some(&b'o'));
+    ///
+    /// let mut sub_cursor = cursor.cursor();
+    ///
+    /// assert_eq!(sub_cursor.next(), Some(&b' '));
+    /// assert_eq!(cursor.next(), Some(&b' '));
+    /// ```
+    fn cursor(&self) -> BufCursor<'_, Self> {
+        BufCursor::new(self)
+    }
+}
+
+macro_rules! deref_forward_seek_buf {
+    () => {
+        #[inline]
+        fn chunk_from(&self, start: usize) -> Option<&[u8]> {
+            (**self).chunk_from(start)
+        }
+
+        #[inline]
+        fn chunk_to(&self, end: usize) -> Option<&[u8]> {
+            (**self).chunk_to(end)
+        }
+
+        #[inline]
+        fn cursor(&self) -> BufCursor<'_, Self> {
+            BufCursor::new(self)
+        }
+    };
+}
+
+impl<T: SeekBuf + ?Sized> SeekBuf for &mut T {
+    deref_forward_seek_buf!();
+}
+
+#[cfg(not(feature = "allocator_api"))]
+impl<T: SeekBuf + ?Sized> SeekBuf for Box<T> {
+    deref_forward_seek_buf!();
+}
+
+#[cfg(feature = "allocator_api")]
+impl<T: SeekBuf + ?Sized, A: core::alloc::Allocator> SeekBuf for Box<T, A> {
+    deref_forward_seek_buf!();
+}
+
+impl<P: SeekBuf> SeekBuf for Pin<P>
+where
+    P: DerefMut + Unpin,
+    P::Target: SeekBuf + Unpin,
+{
+    #[inline]
+    fn chunk_from(&self, start: usize) -> Option<&[u8]> {
+        self.as_ref().get_ref().chunk_from(start)
+    }
+
+    #[inline]
+    fn chunk_to(&self, end: usize) -> Option<&[u8]> {
+        self.as_ref().get_ref().chunk_to(end)
+    }
+
+    #[inline]
+    fn cursor(&self) -> BufCursor<'_, Self> {
+        BufCursor::new(self)
+    }
+}
+
+impl SeekBuf for &[u8] {
+    #[inline]
+    fn chunk_from(&self, start: usize) -> Option<&[u8]> {
+        self.get(start..)
+    }
+
+    #[inline]
+    fn chunk_to(&self, end: usize) -> Option<&[u8]> {
+        self.get(..end)
+    }
+}

--- a/src/buf/vec_deque.rs
+++ b/src/buf/vec_deque.rs
@@ -1,6 +1,6 @@
 use alloc::collections::VecDeque;
 
-use super::Buf;
+use super::{Buf, SeekBuf};
 
 impl Buf for VecDeque<u8> {
     fn remaining(&self) -> usize {
@@ -18,5 +18,33 @@ impl Buf for VecDeque<u8> {
 
     fn advance(&mut self, cnt: usize) {
         self.drain(..cnt);
+    }
+}
+
+impl_with_allocator! {
+    impl SeekBuf for VecDeque<u8> {
+        fn chunk_from(&self, start: usize) -> Option<&[u8]> {
+            let slices = self.as_slices();
+
+            if start < slices.0.len() {
+                Some(&slices.0[start..])
+            } else if start - slices.0.len() < slices.1.len() {
+                Some(&slices.1[start - slices.0.len()..])
+            } else {
+                None
+            }
+        }
+
+        fn chunk_to(&self, end: usize) -> Option<&[u8]> {
+            let slices = self.as_slices();
+
+            if end <= slices.0.len() {
+                Some(&slices.0[..end])
+            } else if end - slices.0.len() <= slices.1.len() {
+                Some(&slices.1[..end - slices.0.len()])
+            } else {
+                None
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
 #![no_std]
+#![cfg_attr(feature = "iter_advance_by", feature(iter_advance_by))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Provides abstractions for working with bytes.
@@ -77,7 +78,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod buf;
-pub use crate::buf::{Buf, BufMut};
+pub use crate::buf::{Buf, BufMut, SeekBuf};
 
 mod bytes;
 mod bytes_mut;

--- a/tests/test_cursor.rs
+++ b/tests/test_cursor.rs
@@ -1,0 +1,81 @@
+#![cfg_attr(feature = "iter_advance_by", feature(iter_advance_by))]
+
+use bytes::SeekBuf;
+
+#[test]
+fn test_iterator() {
+    let buf = b"Hello World!".as_slice();
+
+    let mut cursor = buf.cursor();
+
+    assert_eq!(cursor.next(), Some(&b'H'));
+    assert_eq!(cursor.next(), Some(&b'e'));
+    assert_eq!(cursor.next(), Some(&b'l'));
+    assert_eq!(cursor.next(), Some(&b'l'));
+    assert_eq!(cursor.next(), Some(&b'o'));
+
+    assert_eq!(cursor.next_back(), Some(&b'!'));
+    assert_eq!(cursor.next_back(), Some(&b'd'));
+    assert_eq!(cursor.next_back(), Some(&b'l'));
+    assert_eq!(cursor.next_back(), Some(&b'r'));
+    assert_eq!(cursor.next_back(), Some(&b'o'));
+    assert_eq!(cursor.next_back(), Some(&b'W'));
+
+    assert_eq!(cursor.next(), Some(&b' '));
+
+    assert_eq!(cursor.next(), None);
+    assert_eq!(cursor.next_back(), None);
+}
+
+#[test]
+fn test_seek() {
+    let buf = b"<<< TEXT >>>".as_slice();
+
+    let cursor = buf.cursor().seek(..).unwrap();
+
+    assert_eq!(cursor.cursor().copied().collect::<Vec<u8>>().as_slice(), b"<<< TEXT >>>".as_slice());
+
+    let cursor = buf.cursor().seek(4..8).unwrap();
+
+    assert_eq!(cursor.cursor().copied().collect::<Vec<u8>>().as_slice(), b"TEXT".as_slice());
+
+    let cursor = cursor.seek(0..=1).unwrap();
+
+    assert_eq!(cursor.cursor().copied().collect::<Vec<u8>>().as_slice(), b"TE".as_slice());
+}
+
+#[test]
+fn test_invalid_seek() {
+    let buf = b"123".as_slice();
+
+    assert!(buf.cursor().seek(4..).is_none());
+}
+
+#[test]
+fn test_size() {
+    let buf = b"123456789".as_slice();
+
+    let mut cursor = buf.cursor();
+
+    assert_eq!(cursor.size_hint(), (9, Some(9)));
+
+    cursor.next();
+
+    assert_eq!(cursor.size_hint(), (8, Some(8)));
+}
+
+#[test]
+#[cfg(feature = "iter_advance_by")]
+fn test_advance_by() {
+    let buf = b"123456789".as_slice();
+
+    let mut cursor = buf.cursor();
+
+    cursor.advance_by(4).unwrap();
+
+    assert_eq!(cursor.cursor().copied().collect::<Vec<u8>>().as_slice(), b"56789".as_slice());
+
+    cursor.advance_back_by(4).unwrap();
+
+    assert_eq!(cursor.cursor().copied().collect::<Vec<u8>>().as_slice(), b"5".as_slice());
+}

--- a/tests/test_seek_buf.rs
+++ b/tests/test_seek_buf.rs
@@ -1,0 +1,35 @@
+use bytes::{Buf, SeekBuf};
+
+#[test]
+fn test_seek_buf_cursor() {
+    let buf = b"try to find the T in the haystack".as_slice();
+
+    let remaining = buf.remaining();
+
+    assert!(buf.cursor().find(|&&b| b == b'Q').is_none());
+    assert!(buf.cursor().find(|&&b| b == b'T').is_some());
+
+    // No bytes in the buffer were consumed while using the cursor.
+    assert_eq!(remaining, buf.remaining());
+}
+
+#[test]
+fn test_chunk_from() {
+    let buf = b"hello world".as_slice();
+
+    assert_eq!(buf.chunk_from(6), Some(b"world".as_slice()));
+    assert_eq!(buf.chunk_from(100), None);
+}
+
+#[test]
+fn test_chunk_to() {
+    let buf = b"hello world".as_slice();
+
+    assert_eq!(buf.chunk_to(5), Some(b"hello".as_slice()));
+    assert_eq!(buf.chunk_to(100), None);
+
+    // It may not be intuitive, but an identity of `chunk_to` is that when
+    // passed an `end` of zero, it will always return an empty slice instead
+    // of `None`.
+    assert_eq!([].as_slice().chunk_to(0), Some([].as_slice()));
+}


### PR DESCRIPTION
Fixes #657.

This PR introduces the `SeekBuf` trait for buffers that support arbitrary lookups of memory, and a new `BufCursor` struct for immutably iterating over a `SeekBuf` type.

`SeekBuf` is strictly an opt-in trait with additional functionality over the standard `Buf` trait and otherwise does not change the API of this crate.

The `BufCursor` type provides compatibility to a wide range of core/std Rust features through its `Iterator` implementation. It also allows recursive and non-consuming access to the full memory of a buffer that was otherwise not possible via the `Buf` trait.

Optionally, this diff also adds support for the unstable `iter_advance_by` feature, which is very useful for quickly advancing the buffer without calling the expensive `next` or `next_back` operations, but can be moved to a separate PR pending discussion on enabling unstable features in this crate.

