### PR TITLE
Remove some unnecessary namespaces

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -556,7 +556,7 @@ impl Buf for Bytes {
         }
     }
 
-    fn copy_to_bytes(&mut self, len: usize) -> crate::Bytes {
+    fn copy_to_bytes(&mut self, len: usize) -> Self {
         if len == self.remaining() {
             core::mem::replace(self, Bytes::new())
         } else {

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1078,7 +1078,7 @@ impl Buf for BytesMut {
         }
     }
 
-    fn copy_to_bytes(&mut self, len: usize) -> crate::Bytes {
+    fn copy_to_bytes(&mut self, len: usize) -> Bytes {
         self.split_to(len).freeze()
     }
 }
@@ -1110,7 +1110,7 @@ unsafe impl BufMut for BytesMut {
     // Specialize these methods so they can skip checking `remaining_mut`
     // and `advance_mut`.
 
-    fn put<T: crate::Buf>(&mut self, mut src: T)
+    fn put<T: Buf>(&mut self, mut src: T)
     where
         Self: Sized,
     {


### PR DESCRIPTION
These items are already in scope. No need for the `crate::` namespace!