### PR TITLE
Remove an unnecessary else

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -726,10 +726,10 @@ impl BytesMut {
                 }
 
                 return;
-            } else {
-                new_cap = cmp::max(new_cap, original_capacity);
             }
         }
+
+        new_cap = cmp::max(new_cap, original_capacity);
 
         // Create a new vector to store the data
         let mut v = ManuallyDrop::new(Vec::with_capacity(new_cap));


### PR DESCRIPTION
The if block above always returns, acting as a guard, so there's no reason for an else here.