### PR TITLE
Refactor split_at/split_to

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -888,13 +888,7 @@ impl BytesMut {
         // new start and updating the `len` field to reflect the new length
         // of the view.
         self.ptr = vptr(self.ptr.as_ptr().add(start));
-
-        if self.len >= start {
-            self.len -= start;
-        } else {
-            self.len = 0;
-        }
-
+        self.len = self.len.checked_sub(start).unwrap_or(0);
         self.cap -= start;
     }
 

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -318,8 +318,6 @@ impl BytesMut {
         unsafe {
             let mut other = self.shallow_clone();
             other.set_start(at);
-            assert!(at <= self.cap, "set_end out of bounds");
-
             self.cap = at;
             self.len = cmp::min(self.len, at);
             other

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -393,11 +393,11 @@ impl BytesMut {
 
         unsafe {
             let mut other = self.shallow_clone();
-            other.cap = at;
-            other.len = at;
             // SAFETY: We've checked that `at` <= `self.len()` and we know that `self.len()` <=
             // `self.capacity()`.
             self.advance_unchecked(at);
+            other.cap = at;
+            other.len = at;
             other
         }
     }

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -318,7 +318,6 @@ impl BytesMut {
         unsafe {
             let mut other = self.shallow_clone();
             other.set_start(at);
-            debug_assert_eq!(self.kind(), KIND_ARC);
             assert!(at <= self.cap, "set_end out of bounds");
 
             self.cap = at;
@@ -395,7 +394,6 @@ impl BytesMut {
 
         unsafe {
             let mut other = self.shallow_clone();
-            debug_assert_eq!(other.kind(), KIND_ARC);
             assert!(at <= other.cap, "set_end out of bounds");
 
             other.cap = at;

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -392,10 +392,8 @@ impl BytesMut {
 
         unsafe {
             let mut other = self.shallow_clone();
-            assert!(at <= other.cap, "set_end out of bounds");
-
             other.cap = at;
-            other.len = cmp::min(other.len, at);
+            other.len = at;
             self.set_start(at);
             other
         }


### PR DESCRIPTION
I did a little refactoring of `split_at` and `split_to` to remove some extraneous checks and add some clarity around safety guarantees.

Each commit is fairly self-contained, but here are the highlights with some rationale:

1. I set `len` a little more concisely in ea9dd6050463185b8d4a9022218763902abd7c1c.
1. `split_at` and `split_to` are doing redundant bounds checking and comparison that I removed in 851b59be852b30bfa8da6b309846c37f78c41b42 and 8381ab7168ac31e2ae4d63548dcb62b6abba77b9.
1. I renamed `set_start` to `advance_unchecked` to better reflect it's usage in c70d6d2598f506a1693a08beff4e3ae6a0e23d27. I also added some explicit comments about the safety guarantees of that method and an explanation of why each usage is sound.

I'm pretty new to this repo, so if I've missed some rules or norms please let me know. I'll be happy to change things up!