### PR TITLE
Improve the performance of put_u8 and put_i8

### DIFF
--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -319,6 +319,10 @@ pub unsafe trait BufMut {
     /// `self`.
     #[inline]
     fn put_u8(&mut self, n: u8) {
+        if self.remaining_mut() < 1 {
+            panic_advance(1, self.remaining_mut());
+        }
+
         let dst = self.chunk_mut();
         unsafe {
             dst.as_mut_ptr().write(n);

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -319,8 +319,11 @@ pub unsafe trait BufMut {
     /// `self`.
     #[inline]
     fn put_u8(&mut self, n: u8) {
-        let src = [n];
-        self.put_slice(&src);
+        let dst = self.chunk_mut();
+        unsafe {
+            dst.as_mut_ptr().write(n);
+            self.advance_mut(1)
+        };
     }
 
     /// Writes a signed 8 bit integer to `self`.
@@ -343,8 +346,7 @@ pub unsafe trait BufMut {
     /// `self`.
     #[inline]
     fn put_i8(&mut self, n: i8) {
-        let src = [n as u8];
-        self.put_slice(&src)
+        self.put_u8(n as u8)
     }
 
     /// Writes an unsigned 16 bit integer to `self` in big-endian byte order.


### PR DESCRIPTION
When using `put_u8/put_i8`, it internally wraps the `u8/i8` into `&[u8]`, and then calls `put_slice()`. Wrapping it into &[u8] is an unnecessary operation. So I optimized this step.

Here's the benchmark below：

**Before**
`test put_u8_bytes_mut         ... bench:         333 ns/iter (+/- 70) = 384 MB/s`

**After**
`test put_u8_bytes_mut         ... bench:         271 ns/iter (+/- 8) = 472 MB/s`