### PR TITLE
Use Iterator from the prelude

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1,4 +1,4 @@
-use core::iter::{FromIterator, Iterator};
+use core::iter::FromIterator;
 use core::mem::{self, ManuallyDrop, MaybeUninit};
 use core::ops::{Deref, DerefMut};
 use core::ptr::{self, NonNull};


### PR DESCRIPTION
CI is [failing][failure] due to `unused_imports` because `Iterator` is already in the prelude. Removing it fixes things up.

```
error: the item `Iterator` is imported redundantly
  --> src/bytes_mut.rs:1:32
   |
1  | use core::iter::{FromIterator, Iterator};
   |                                ^^^^^^^^
   |
  ::: /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/prelude/mod.rs:28:13
   |
28 |     pub use super::v1::*;
   |             --------- the item `Iterator` is already defined here
   |
   = note: `-D unused-imports` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_imports)]`
```

[failure]: https://github.com/tokio-rs/bytes/actions/runs/8034858583/job/21946873895