### PR TITLE
Remove redundant reserve call

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1283,7 +1283,6 @@ impl Extend<u8> for BytesMut {
 
         // TODO: optimize
         // 1. If self.kind() == KIND_VEC, use Vec::extend
-        // 2. Make `reserve` inline-able
         for b in iter {
             self.put_u8(b);
         }

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1285,7 +1285,6 @@ impl Extend<u8> for BytesMut {
         // 1. If self.kind() == KIND_VEC, use Vec::extend
         // 2. Make `reserve` inline-able
         for b in iter {
-            self.reserve(1);
             self.put_u8(b);
         }
     }


### PR DESCRIPTION
*Note: Miri is currently failing in CI, but is fixed by https://github.com/tokio-rs/bytes/pull/673*

We're calling `reserve` twice because `put_u8` already calls it.

1. put_u8 [calls put_slice](https://github.com/tokio-rs/bytes/blob/46289278f52a26c12298779f4aaebad1dcb26d35/src/buf/buf_mut.rs#L323)
2. BytesMut::put_slice [calls BytesMut::extend_from_slice](https://github.com/tokio-rs/bytes/blob/46289278f52a26c12298779f4aaebad1dcb26d35/src/bytes_mut.rs#L1119)
3. BytesMut::extend_from_slice immediately [calls reserve](https://github.com/tokio-rs/bytes/blob/46289278f52a26c12298779f4aaebad1dcb26d35/src/bytes_mut.rs#L773)