### PR TITLE
Use ManuallyDrop instead of mem::forget

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1617,6 +1617,7 @@ impl PartialEq<Bytes> for BytesMut {
 impl From<BytesMut> for Vec<u8> {
     fn from(bytes: BytesMut) -> Self {
         let kind = bytes.kind();
+        let bytes = ManuallyDrop::new(bytes);
 
         let mut vec = if kind == KIND_VEC {
             unsafe {
@@ -1633,7 +1634,7 @@ impl From<BytesMut> for Vec<u8> {
 
                 vec
             } else {
-                return bytes.deref().to_vec();
+                return ManuallyDrop::into_inner(bytes).deref().to_vec();
             }
         };
 
@@ -1643,8 +1644,6 @@ impl From<BytesMut> for Vec<u8> {
             ptr::copy(bytes.ptr.as_ptr(), vec.as_mut_ptr(), len);
             vec.set_len(len);
         }
-
-        mem::forget(bytes);
 
         vec
     }

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -828,11 +828,11 @@ impl BytesMut {
     // internal change could make a simple pattern (`BytesMut::from(vec)`)
     // suddenly a lot more expensive.
     #[inline]
-    pub(crate) fn from_vec(mut vec: Vec<u8>) -> BytesMut {
+    pub(crate) fn from_vec(vec: Vec<u8>) -> BytesMut {
+        let mut vec = ManuallyDrop::new(vec);
         let ptr = vptr(vec.as_mut_ptr());
         let len = vec.len();
         let cap = vec.capacity();
-        mem::forget(vec);
 
         let original_capacity_repr = original_capacity_to_repr(cap);
         let data = (original_capacity_repr << ORIGINAL_CAPACITY_OFFSET) | KIND_VEC;


### PR DESCRIPTION
This change converts several usages of `mem::forget` to `ManuallyDrop` as recommended [in the docs][docs] for `mem::forget`.

> While mem::forget can also be used to transfer memory ownership, doing so is error-prone. [ManuallyDrop](https://doc.rust-lang.org/std/mem/struct.ManuallyDrop.html) should be used instead.

[docs]: https://doc.rust-lang.org/std/mem/fn.forget.html#relationship-with-manuallydrop