### PR TITLE
Bytes: Use ManuallyDrop instead of mem::forget

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1117,11 +1117,10 @@ unsafe fn shared_to_vec_impl(shared: *mut Shared, ptr: *const u8, len: usize) ->
         .compare_exchange(1, 0, Ordering::AcqRel, Ordering::Relaxed)
         .is_ok()
     {
-        let buf = (*shared).buf;
-        let cap = (*shared).cap;
-
-        // Deallocate Shared
-        drop(Box::from_raw(shared as *mut ManuallyDrop<Shared>));
+        // Deallocate the `Shared` instance without running its destructor.
+        let shared = ManuallyDrop::new(*Box::from_raw(shared));
+        let buf = shared.buf;
+        let cap = shared.cap;
 
         // Copy back buffer
         ptr::copy(ptr, buf, len);

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,6 +1,7 @@
 use core::iter::FromIterator;
+use core::mem::{self, ManuallyDrop};
 use core::ops::{Deref, RangeBounds};
-use core::{cmp, fmt, hash, mem, ptr, slice, usize};
+use core::{cmp, fmt, hash, ptr, slice, usize};
 
 use alloc::{
     alloc::{dealloc, Layout},
@@ -900,7 +901,7 @@ impl From<String> for Bytes {
 
 impl From<Bytes> for Vec<u8> {
     fn from(bytes: Bytes) -> Vec<u8> {
-        let bytes = mem::ManuallyDrop::new(bytes);
+        let bytes = ManuallyDrop::new(bytes);
         unsafe { (bytes.vtable.to_vec)(&bytes.data, bytes.ptr, bytes.len) }
     }
 }
@@ -1120,7 +1121,7 @@ unsafe fn shared_to_vec_impl(shared: *mut Shared, ptr: *const u8, len: usize) ->
         let cap = (*shared).cap;
 
         // Deallocate Shared
-        drop(Box::from_raw(shared as *mut mem::ManuallyDrop<Shared>));
+        drop(Box::from_raw(shared as *mut ManuallyDrop<Shared>));
 
         // Copy back buffer
         ptr::copy(ptr, buf, len);

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1119,7 +1119,8 @@ unsafe fn shared_to_vec_impl(shared: *mut Shared, ptr: *const u8, len: usize) ->
         .is_ok()
     {
         // Deallocate the `Shared` instance without running its destructor.
-        let shared = ManuallyDrop::new(*Box::from_raw(shared));
+        let shared = *Box::from_raw(shared);
+        let shared = ManuallyDrop::new(shared);
         let buf = shared.buf;
         let cap = shared.cap;
 


### PR DESCRIPTION
*Note: The `tsan` job is failing in CI due to https://github.com/rust-lang/rust/issues/122476, which should be resolved in the next few days.*

Much like https://github.com/tokio-rs/bytes/pull/675, I found a few places we can more idiomatically use `ManuallyDrop`.