### PR TITLE
Don't set `len` in `BytesMut::reserve`

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -639,7 +639,6 @@ impl BytesMut {
 
                     // Update the info
                     self.ptr = vptr(v.as_mut_ptr().add(off));
-                    self.len = v.len() - off;
                     self.cap = v.capacity() - off;
                 }
 
@@ -746,7 +745,6 @@ impl BytesMut {
         let data = (original_capacity_repr << ORIGINAL_CAPACITY_OFFSET) | KIND_VEC;
         self.data = invalid_ptr(data);
         self.ptr = vptr(v.as_mut_ptr());
-        self.len = v.len();
         self.cap = v.capacity();
     }
 

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -640,6 +640,7 @@ impl BytesMut {
                     // Update the info
                     self.ptr = vptr(v.as_mut_ptr().add(off));
                     self.cap = v.capacity() - off;
+                    debug_assert_eq!(self.len, v.len() - off);
                 }
 
                 return;
@@ -746,6 +747,7 @@ impl BytesMut {
         self.data = invalid_ptr(data);
         self.ptr = vptr(v.as_mut_ptr());
         self.cap = v.capacity();
+        debug_assert_eq!(self.len, v.len());
     }
 
     /// Appends given bytes to this `BytesMut`.


### PR DESCRIPTION
A fundamental invariant of `reserve` is that it can extend capacity while the stored data remains the same, even if it's moved to a new allocation. As a result, `len` can never change during a call to `reserve`.