### PR TITLE
Implement `Bytes::from_raw_parts`

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -557,11 +557,11 @@ impl Bytes {
     ///     handle_alloc_error(layout);
     /// };
     ///
-    /// // (Not shown here: Pass `ptr` and `LEN` to code that will write data into the buffer.
+    /// // (Not shown here: Pass `ptr` to code that will write data into the buffer.
     /// // For example, pass `ptr` to a system call to load data from disk using `O_DIRECT`.)
     ///
-    /// let buf = Bytes::from_raw_parts(ptr, LEN);
-    /// assert_eq!(buf.len(), LEN);
+    /// let buf = Bytes::from_raw_parts(ptr, layout.size());
+    /// assert_eq!(buf.len(), layout.size());
     /// ```
     pub fn from_raw_parts(ptr: *const u8, len: usize) -> Self {
         let ptr = ptr as *mut u8;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -556,8 +556,10 @@ impl Bytes {
     /// if ptr.is_null() {
     ///     handle_alloc_error(layout);
     /// };
+    ///
     /// // (Not shown here: Pass `ptr` and `LEN` to code that will write data into the buffer.
     /// // For example, pass `ptr` to a system call to load data from disk using `O_DIRECT`.)
+    ///
     /// let buf = Bytes::from_raw_parts(ptr, LEN);
     /// assert_eq!(buf.len(), LEN);
     /// ```

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1172,20 +1172,3 @@ fn shared_is_unique() {
     drop(b);
     assert!(c.is_unique());
 }
-
-#[test]
-fn test_bytes_new_aligned_uninit() {
-    const LEN: usize = 128;
-    const ALIGN: usize = 32;
-    let b = Bytes::new_aligned_uninit(LEN, ALIGN);
-    assert_eq!(b.len(), LEN);
-
-    // Mimic the operating system writing into this buffer:
-    let ptr = b.as_ptr() as *mut u8;
-    (0..LEN).for_each(|i| unsafe {
-        *ptr.offset(i as isize) = i as u8;
-    });
-
-    // Check the data:
-    (0..LEN).for_each(|i| assert_eq!(b[i], i as u8));
-}

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1172,3 +1172,20 @@ fn shared_is_unique() {
     drop(b);
     assert!(c.is_unique());
 }
+
+#[test]
+fn test_bytes_new_aligned_uninit() {
+    const LEN: usize = 128;
+    const ALIGN: usize = 32;
+    let b = Bytes::new_aligned_uninit(LEN, ALIGN);
+    assert_eq!(b.len(), LEN);
+
+    // Mimic the operating system writing into this buffer:
+    let ptr = b.as_ptr() as *mut u8;
+    (0..LEN).for_each(|i| unsafe {
+        *ptr.offset(i as isize) = i as u8;
+    });
+
+    // Check the data:
+    (0..LEN).for_each(|i| assert_eq!(b[i], i as u8));
+}


### PR DESCRIPTION
## Use-case

I need to construct buffers which are aligned to 512-byte boundaries, in order to read data from disk using `O_DIRECT` on Linux (see issue #600 for a user who has the same use-case as me).

Once the operating system has written into these buffers, I'd love to wrap the buffer in `Bytes` so I can:
- share read-only access to multiple "owned" slices of the buffer.
- match existing API's like `object_store`'s API which returns `Bytes`.

Wrapping an aligned buffer _is_ possible today using `Bytes` as it current stands (although I'm not entirely certain if this will be safely `drop`'d in all situations, because `Bytes::drop` doesn't know the alignment??):

```rust
fn get_aligned_bytes(len: usize, align: usize) -> bytes::Bytes {
    assert_ne!(len, 0);
    let layout = Layout::from_size_align(len, align)
        .expect("failed to create Layout!")
        .pad_to_align();
    let boxed_slice = unsafe {
        let ptr = alloc(layout);
        if ptr.is_null() {
            handle_alloc_error(layout);
        };
        let s = slice::from_raw_parts_mut(ptr, len);
        Box::from_raw(s as *mut [u8])
    };
    bytes::Bytes::from(boxed_slice)
}
```

However, that requires two unnecessary steps: `slice::from_raw_parts_mut` and `Box::from_raw`.

This PR adds a very simple `Bytes::from_raw_parts` method (which is mostly copied from `impl From<Box[u8]> for Bytes`).

With this new PR, wrapping an aligned buffer in `Bytes` is a little more ergonomic for users, and a little more computationally efficient:

```rust
fn get_aligned_bytes(len: usize, align: usize) -> bytes::Bytes {
    assert_ne!(len, 0);
    let layout = Layout::from_size_align(len, align)
        .expect("failed to create Layout!")
        .pad_to_align();
    let ptr = unsafe { alloc(layout) };
    if ptr.is_null() {
        handle_alloc_error(layout);
    };
    bytes::Bytes::from_raw_parts(ptr, layout.size())
}
```

(This is my first PR to a Rust open-source project, so please LMK if I've done anything wrong!)

## TODO:
- [ ] I assume I need to define a new `static Vtable` where `Vtable.drop` knows the alignment of the data to drop. Is that correct? Is that even possible, given that `struct Vtable.drop` can't accept a closure?! Maybe the solution is to create a macro to insert the alignment into the drop function (although that will only work when we know the alignment at compile time... although, for aligned buffers for `O_DIRECT`, we could create a handful of alignments (e.g. 512-bytes and 4096-bytes) at compile-time, and select the correct one at runtime.)
- [ ] If this PR is accepted, then a follow-on PR could simplify `impl From<Box[u8]> for Bytes` by calling `Bytes::from_raw_parts`.

## Related

- #600 
- #601 
- #607