### PR TITLE
Bytes::split_to - check fast path first

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -434,13 +434,6 @@ impl Bytes {
     /// Panics if `at > len`.
     #[must_use = "consider Bytes::advance if you don't need the other half"]
     pub fn split_to(&mut self, at: usize) -> Self {
-        assert!(
-            at <= self.len(),
-            "split_to out of bounds: {:?} <= {:?}",
-            at,
-            self.len(),
-        );
-
         if at == self.len() {
             return mem::replace(self, Bytes::new());
         }
@@ -448,6 +441,13 @@ impl Bytes {
         if at == 0 {
             return Bytes::new();
         }
+
+        assert!(
+            at <= self.len(),
+            "split_to out of bounds: {:?} <= {:?}",
+            at,
+            self.len(),
+        );
 
         let mut ret = self.clone();
 


### PR DESCRIPTION
If `at == self.len()` then we already know `at <= self.len()`. If `at == 0`, it can't be greater than `self.len()`.