### PR TITLE
Truncate tweaks

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -424,6 +424,7 @@ impl BytesMut {
     pub fn truncate(&mut self, len: usize) {
         if len < self.len() {
             unsafe {
+                // SAFETY: Shrinking the buffer cannot expose uninitialized bytes.
                 self.set_len(len);
             }
         }

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -422,7 +422,7 @@ impl BytesMut {
     /// assert_eq!(buf, b"hello"[..]);
     /// ```
     pub fn truncate(&mut self, len: usize) {
-        if len <= self.len() {
+        if len < self.len() {
             unsafe {
                 self.set_len(len);
             }


### PR DESCRIPTION
This is a quick tweak to `BytesMut::truncate` to avoid calling `BytesMut::set_len` unnecessarily and to explicitly state assumptions of safety.