### PR TITLE
Resize refactor

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -468,9 +468,7 @@ impl BytesMut {
     /// assert_eq!(&buf[..], &[0x1, 0x1, 0x3, 0x3]);
     /// ```
     pub fn resize(&mut self, new_len: usize, value: u8) {
-        let len = self.len();
-        if new_len > len {
-            let additional = new_len - len;
+        if let Some(additional) = new_len.checked_sub(self.len()) {
             self.reserve(additional);
             unsafe {
                 let dst = self.chunk_mut().as_mut_ptr();

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -469,6 +469,10 @@ impl BytesMut {
     /// ```
     pub fn resize(&mut self, new_len: usize, value: u8) {
         if let Some(additional) = new_len.checked_sub(self.len()) {
+            if additional == 0 {
+                return;
+            }
+
             self.reserve(additional);
             unsafe {
                 let dst = self.chunk_mut().as_mut_ptr();

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -474,7 +474,7 @@ impl BytesMut {
             }
 
             self.reserve(additional);
-            let dst = self.chunk_mut().as_mut_ptr();
+            let dst = self.spare_capacity_mut().as_mut_ptr();
             unsafe {
                 ptr::write_bytes(dst, value, additional);
                 self.set_len(new_len);

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -481,15 +481,13 @@ impl BytesMut {
 
         self.reserve(additional);
         let dst = self.spare_capacity_mut().as_mut_ptr();
-        unsafe {
-            // SAFETY: `spare_capacity_mut` returns a valid, properly aligned pointer and we've
-            // reserved enough space to write `additional` bytes.
-            ptr::write_bytes(dst, value, additional);
+        // SAFETY: `spare_capacity_mut` returns a valid, properly aligned pointer and we've
+        // reserved enough space to write `additional` bytes.
+        unsafe { ptr::write_bytes(dst, value, additional) };
 
-            // SAFETY: There are at least `new_len` initialized bytes in the buffer so no
-            // uninitialized bytes are being exposed.
-            self.set_len(new_len);
-        }
+        // SAFETY: There are at least `new_len` initialized bytes in the buffer so no
+        // uninitialized bytes are being exposed.
+        unsafe { self.set_len(new_len) };
     }
 
     /// Sets the length of the buffer.

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -476,7 +476,12 @@ impl BytesMut {
             self.reserve(additional);
             let dst = self.spare_capacity_mut().as_mut_ptr();
             unsafe {
+                // SAFETY: `spare_capacity_mut` returns a valid, properly aligned pointer and we've
+                // reserved enough space to write `additional` bytes.
                 ptr::write_bytes(dst, value, additional);
+
+                // SAFETY: There are at least `new_len` initialized bytes in the buffer so no
+                // uninitialized bytes are being exposed.
                 self.set_len(new_len);
             }
         } else {

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -474,8 +474,8 @@ impl BytesMut {
             }
 
             self.reserve(additional);
+            let dst = self.chunk_mut().as_mut_ptr();
             unsafe {
-                let dst = self.chunk_mut().as_mut_ptr();
                 ptr::write_bytes(dst, value, additional);
                 self.set_len(new_len);
             }

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -468,18 +468,17 @@ impl BytesMut {
     /// assert_eq!(&buf[..], &[0x1, 0x1, 0x3, 0x3]);
     /// ```
     pub fn resize(&mut self, new_len: usize, value: u8) {
-        let additional = new_len.checked_sub(self.len());
-
-        if additional.is_none() {
+        let additional = if let Some(additional) = new_len.checked_sub(self.len()) {
+            additional
+        } else {
             self.truncate(new_len);
             return;
-        }
+        };
 
-        if additional == Some(0) {
+        if additional == 0 {
             return;
         }
 
-        let additional = additional.unwrap();
         self.reserve(additional);
         let dst = self.spare_capacity_mut().as_mut_ptr();
         unsafe {


### PR DESCRIPTION
I've done a little refactoring of `BytesMut:resize` here to increase clarity, handle a few edge cases, and explicitly state soundness assumptions about unsafe code.

As I stated in my commits, this would be nicer with a `let-else` block, but that isn't currently covered by our MSRV.