### PR TITLE
Reuse capacity when possible in `<BytesMut as Buf>::advance` impl

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1066,6 +1066,14 @@ impl Buf for BytesMut {
 
     #[inline]
     fn advance(&mut self, cnt: usize) {
+        // Advancing by the length is the same as resetting the length to 0,
+        // except this way we get to reuse the full capacity.
+        if cnt == self.remaining() {
+            // SAFETY: Zero is not greater than the capacity.
+            unsafe { self.set_len(0) };
+            return;
+        }
+
         assert!(
             cnt <= self.remaining(),
             "cannot advance past `remaining`: {:?} <= {:?}",


### PR DESCRIPTION
While thinking about usage of `BytesMut` in my own code I've realized sometimes the following pattern (explained by the following pseudocode) is encountered:

```rs
let mut buf = BytesMut::with_capacity(8196);

loop {
    read_into_bufmut(&mut buf);

    if some_condition {
        // consume the data and then discard it
        let consumed = process_data(&buf);
        buf.advance(consumed);
        // in most cases the above `advance` ends-up consuming the entire length of `buf`
    } else {
        // consume the data as `Bytes`
        ship_data(buf.split().freeze());

        // (this is just to explain that `VecDeque` wouldn't be efficient here)
    }
}
```

In this particular example it would be more efficient to `buf.clear()` when `consumed == buf.len()`, instead of calling `advance` and eventually ending-up going through the allocation machinery.

This PR makes `advance` do it automatically for cases in which it's safe to do (which is why I didn't put it inside `advance_unchecked`). I'm not sure the `Buf` API allows it, the only thing I've found is `#[must_use = "consider BytesMut::advance(len()) if you don't need the other half"]` on `BytesMut::split()`.