### PR TITLE
Improve BytesMut::split suggestion

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -349,7 +349,7 @@ impl BytesMut {
     ///
     /// assert_eq!(other, b"hello world"[..]);
     /// ```
-    #[must_use = "consider BytesMut::advance(len()) if you don't need the other half"]
+    #[must_use = "consider BytesMut::clear if you don't need the other half"]
     pub fn split(&mut self) -> BytesMut {
         let len = self.len();
         self.split_to(len)


### PR DESCRIPTION
Incorporates the improvement from #698 into the `must_use` suggestion of `BytesMut::split`.