### PR TITLE
Silence unexpected-cfgs warnings due to `#[cfg(loom)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unexpected_cfgs)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,


### PR DESCRIPTION
Silence warnings from #13571 due to our use of `#[cfg(loom)]`