### PR TITLE
Offset from

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -15,7 +15,7 @@ use crate::buf::IntoIter;
 #[allow(unused)]
 use crate::loom::sync::atomic::AtomicMut;
 use crate::loom::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
-use crate::{Buf, BytesMut};
+use crate::{offset_from, Buf, BytesMut};
 
 /// A cheaply cloneable and sliceable chunk of contiguous memory.
 ///
@@ -1420,23 +1420,6 @@ where
     let old_addr = ptr as usize;
     let new_addr = f(old_addr);
     new_addr as *mut u8
-}
-
-/// Precondition: dst >= original
-///
-/// The following line is equivalent to:
-///
-/// ```rust,ignore
-/// self.ptr.as_ptr().offset_from(ptr) as usize;
-/// ```
-///
-/// But due to min rust is 1.39 and it is only stabilized
-/// in 1.47, we cannot use it.
-#[inline]
-fn offset_from(dst: *const u8, original: *const u8) -> usize {
-    debug_assert!(dst >= original);
-
-    dst as usize - original as usize
 }
 
 // compile-fails

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1037,7 +1037,7 @@ unsafe fn promotable_to_vec(
 
         let buf = f(shared);
 
-        let cap = (ptr as usize - buf as usize) + len;
+        let cap = offset_from(ptr, buf) + len;
 
         // Copy back buffer
         ptr::copy(ptr, buf, len);
@@ -1150,7 +1150,7 @@ unsafe fn promotable_is_unique(data: &AtomicPtr<()>) -> bool {
 }
 
 unsafe fn free_boxed_slice(buf: *mut u8, offset: *const u8, len: usize) {
-    let cap = (offset as usize - buf as usize) + len;
+    let cap = offset_from(offset, buf) + len;
     dealloc(buf, Layout::from_size_align(cap, 1).unwrap())
 }
 
@@ -1312,7 +1312,7 @@ unsafe fn shallow_clone_vec(
     // vector.
     let shared = Box::new(Shared {
         buf,
-        cap: (offset as usize - buf as usize) + len,
+        cap: offset_from(offset, buf) + len,
         // Initialize refcount to 2. One for this reference, and one
         // for the new clone that will be returned from
         // `shallow_clone`.

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -17,7 +17,7 @@ use crate::bytes::Vtable;
 #[allow(unused)]
 use crate::loom::sync::atomic::AtomicMut;
 use crate::loom::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
-use crate::{Buf, BufMut, Bytes};
+use crate::{offset_from, Buf, BufMut, Bytes};
 
 /// A unique reference to a contiguous slice of memory.
 ///
@@ -1681,23 +1681,6 @@ fn invalid_ptr<T>(addr: usize) -> *mut T {
     let ptr = core::ptr::null_mut::<u8>().wrapping_add(addr);
     debug_assert_eq!(ptr as usize, addr);
     ptr.cast::<T>()
-}
-
-/// Precondition: dst >= original
-///
-/// The following line is equivalent to:
-///
-/// ```rust,ignore
-/// self.ptr.as_ptr().offset_from(ptr) as usize;
-/// ```
-///
-/// But due to min rust is 1.39 and it is only stabilized
-/// in 1.47, we cannot use it.
-#[inline]
-fn offset_from(dst: *mut u8, original: *mut u8) -> usize {
-    debug_assert!(dst >= original);
-
-    dst as usize - original as usize
 }
 
 unsafe fn rebuild_vec(ptr: *mut u8, mut len: usize, mut cap: usize, off: usize) -> Vec<u8> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,3 +148,20 @@ fn panic_does_not_fit(size: usize, nbytes: usize) -> ! {
         size, nbytes
     );
 }
+
+/// Precondition: dst >= original
+///
+/// The following line is equivalent to:
+///
+/// ```rust,ignore
+/// self.ptr.as_ptr().offset_from(ptr) as usize;
+/// ```
+///
+/// But due to min rust is 1.39 and it is only stabilized
+/// in 1.47, we cannot use it.
+#[inline]
+fn offset_from(dst: *const u8, original: *const u8) -> usize {
+    debug_assert!(dst >= original);
+
+    dst as usize - original as usize
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,5 @@ fn panic_does_not_fit(size: usize, nbytes: usize) -> ! {
 /// in 1.47, we cannot use it.
 #[inline]
 fn offset_from(dst: *const u8, original: *const u8) -> usize {
-    debug_assert!(dst >= original);
-
     dst as usize - original as usize
 }


### PR DESCRIPTION
In #695, @Sytten added a separate version of `offset_from` for `*const u8` (thanks @Sytten). After some digging, I found that we can use the new one for both cases. Further, there are several additional places we can/should be using `offset_from` instead of subtracting directly.