### PR TITLE
Fix iter tests to use the actual bytes `IntoIter` instead of std

### DIFF
--- a/tests/test_iter.rs
+++ b/tests/test_iter.rs
@@ -1,11 +1,11 @@
 #![warn(rust_2018_idioms)]
 
-use bytes::Bytes;
+use bytes::{buf::IntoIter, Bytes};
 
 #[test]
 fn iter_len() {
     let buf = Bytes::from_static(b"hello world");
-    let iter = buf.iter();
+    let iter = IntoIter::new(buf);
 
     assert_eq!(iter.size_hint(), (11, Some(11)));
     assert_eq!(iter.len(), 11);
@@ -13,8 +13,8 @@ fn iter_len() {
 
 #[test]
 fn empty_iter_len() {
-    let buf = Bytes::from_static(b"");
-    let iter = buf.iter();
+    let buf = Bytes::new();
+    let iter = IntoIter::new(buf);
 
     assert_eq!(iter.size_hint(), (0, Some(0)));
     assert_eq!(iter.len(), 0);


### PR DESCRIPTION
While looking at the code I've realized the iterator tests were using `core::slice::Iter` instead of `bytes::buf::IntoIter`. This mistake seems to be an artifact of bytes 0.4 [^1]. This fixes it.

[^1]: https://docs.rs/bytes/0.4.12/bytes/buf/trait.Buf.html#method.iter