### PR TITLE
Implement `Buf::chunks_vectored` for `VecDeque<u8>`

### DIFF
--- a/src/buf/vec_deque.rs
+++ b/src/buf/vec_deque.rs
@@ -1,4 +1,6 @@
 use alloc::collections::VecDeque;
+#[cfg(feature = "std")]
+use std::io;
 
 use super::Buf;
 
@@ -14,6 +16,22 @@ impl Buf for VecDeque<u8> {
         } else {
             s1
         }
+    }
+
+    #[cfg(feature = "std")]
+    fn chunks_vectored<'a>(&'a self, dst: &mut [io::IoSlice<'a>]) -> usize {
+        if self.is_empty() || dst.is_empty() {
+            return 0;
+        }
+
+        let (s1, s2) = self.as_slices();
+        dst[0] = io::IoSlice::new(s1);
+        if s2.is_empty() || dst.len() == 1 {
+            return 1;
+        }
+
+        dst[1] = io::IoSlice::new(s2);
+        2
     }
 
     fn advance(&mut self, cnt: usize) {

--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -353,7 +353,7 @@ mod vec_deque {
         deque
     }
 
-    buf_tests!(make_input, /* `VecDeque` does not do `chucks_vectored */ false);
+    buf_tests!(make_input, true);
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
A tiny step closer at making #474 and #701 harder to encounter.
