### PR TITLE
Add optional support for the arbitrary crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ default = ["std"]
 std = []
 
 [dependencies]
+arbitrary = { version = "1.1.6", optional = true }
 serde = { version = "1.0.60", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,0 +1,18 @@
+use super::{Bytes, BytesMut};
+use arbitrary::{Arbitrary, Result};
+
+impl<'a> Arbitrary<'a> for Bytes {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> Result<Self> {
+        let len = u.arbitrary_len::<u8>()?;
+
+        u.bytes(len).map(Bytes::copy_from_slice)
+    }
+}
+
+impl<'a> Arbitrary<'a> for BytesMut {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> Result<Self> {
+        let len = u.arbitrary_len::<u8>()?;
+
+        u.bytes(len).map(|slice| BytesMut::from_vec(slice.to_vec()))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@ pub use crate::bytes_mut::BytesMut;
 #[cfg(feature = "serde")]
 mod serde;
 
+#[cfg(feature = "arbitrary")]
+mod arbitrary;
+
 #[inline(never)]
 #[cold]
 fn abort() -> ! {


### PR DESCRIPTION
This PRs adds optional support for the [arbitrary crate](https://github.com/rust-fuzz/arbitrary/) by deriving the Arbitrary trait for both Bytes and BytesMut.
This is incredibly useful for fuzz testing as it allows for [structure aware fuzzing](https://rust-fuzz.github.io/book/cargo-fuzz/structure-aware-fuzzing.html).
Adding this traits directly allows downstream users to easily derive the traits for their structs:

E.g. from one of my projects

```rust
#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Arbitrary)]
pub struct Message {
    pub object_id: u32,
    pub opcode: u16,
    pub payload: Bytes,
}
```

Without bytes implementing Arbitrary directly this would require some kinda of wrapper struct.