### PR TITLE
Correct is_unique for Bytes from shared BytesMut

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1698,7 +1698,7 @@ unsafe fn rebuild_vec(ptr: *mut u8, mut len: usize, mut cap: usize, off: usize) 
 static SHARED_VTABLE: Vtable = Vtable {
     clone: shared_v_clone,
     to_vec: shared_v_to_vec,
-    is_unique: crate::bytes::shared_is_unique,
+    is_unique: shared_v_is_unique,
     drop: shared_v_drop,
 };
 
@@ -1730,6 +1730,12 @@ unsafe fn shared_v_to_vec(data: &AtomicPtr<()>, ptr: *const u8, len: usize) -> V
         release_shared(shared);
         v
     }
+}
+
+unsafe fn shared_v_is_unique(data: &AtomicPtr<()>) -> bool {
+    let shared = data.load(Ordering::Acquire);
+    let ref_count = (*shared.cast::<Shared>()).ref_count.load(Ordering::Relaxed);
+    ref_count == 1
 }
 
 unsafe fn shared_v_drop(data: &mut AtomicPtr<()>, _ptr: *const u8, _len: usize) {

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1172,3 +1172,12 @@ fn shared_is_unique() {
     drop(b);
     assert!(c.is_unique());
 }
+
+#[test]
+fn mut_shared_is_unique() {
+    let mut b = BytesMut::from(LONG);
+    let c = b.split().freeze();
+    assert!(!c.is_unique());
+    drop(b);
+    assert!(c.is_unique());
+}


### PR DESCRIPTION
The `is_unique` entry in the vtable for `Bytes` created from a shared `BytesMut` just called the `shared_is_unique` function from the `bytes` module. However, that function dereferences the `data` argument as `crate::bytes::Shared`, but the actual underlying type is `crate::bytes_mut::Shared`.