### PR TITLE
Merge 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.6.1 (July 13, 2024)
+
+This release fixes a bug where `Bytes::is_unique` returns incorrect values when
+the `Bytes` originates from a shared `BytesMut`. (#718)
+
 # 1.6.0 (March 22, 2024)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bytes"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.6.0"
+version = "1.6.1"
 edition = "2018"
 rust-version = "1.39"
 license = "MIT"

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1780,7 +1780,7 @@ static SHARED_VTABLE: Vtable = Vtable {
     clone: shared_v_clone,
     to_vec: shared_v_to_vec,
     to_mut: shared_v_to_mut,
-    is_unique: crate::bytes::shared_is_unique,
+    is_unique: shared_v_is_unique,
     drop: shared_v_drop,
 };
 
@@ -1841,6 +1841,12 @@ unsafe fn shared_v_to_mut(data: &AtomicPtr<()>, ptr: *const u8, len: usize) -> B
         release_shared(shared);
         BytesMut::from_vec(v)
     }
+}
+
+unsafe fn shared_v_is_unique(data: &AtomicPtr<()>) -> bool {
+    let shared = data.load(Ordering::Acquire);
+    let ref_count = (*shared.cast::<Shared>()).ref_count.load(Ordering::Relaxed);
+    ref_count == 1
 }
 
 unsafe fn shared_v_drop(data: &mut AtomicPtr<()>, _ptr: *const u8, _len: usize) {

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1174,6 +1174,15 @@ fn shared_is_unique() {
 }
 
 #[test]
+fn mut_shared_is_unique() {
+    let mut b = BytesMut::from(LONG);
+    let c = b.split().freeze();
+    assert!(!c.is_unique());
+    drop(b);
+    assert!(c.is_unique());
+}
+
+#[test]
 fn test_bytesmut_from_bytes_static() {
     let bs = b"1b23exfcz3r";
 


### PR DESCRIPTION
Merges #720 back into the master branch using a merge commit.

Must be merged from the command-line because we want an actual merge commit in the final history. We don't want to squash this change.

The history looks like this:
```
*   f8c7b57 - (3 minutes ago) Merge 'v1.6.1' into 'master' (#721) - Alice Ryhl (merge-1.6.1)
|\
| * fd13c7d - (9 minutes ago) chore: prepare bytes v1.6.1 (#720) - Alice Ryhl (v1.6.x)
| * 6b4b0ed - (9 hours ago) Fix `Bytes::is_unique` when created from shared `BytesMut` (#718) - Emily Crandall Fleischman
* | 9965a04 - (3 days ago) Remove unnecessary file (#719) - EXPLOSION (master)
* | 3443ca5 - (4 days ago) docs: clarify the behavior of `Buf::chunk` (#717) - vvvviiv
* | 8cc9407 - (2 weeks ago) Allow reclaiming the current allocation (#686) - Sebastian Hahn
* | 7a5154b - (3 weeks ago) Clarify how `BytesMut::zeroed` works and advantages to manual impl (#714) - Paolo Barbolini
* | fa1daac - (7 weeks ago) Change Bytes::make_mut to impl From<Bytes> for BytesMut (closes #709) (#710) - Anthony Ramine
* | caf520a - (8 weeks ago) Fix iter tests to use the actual bytes IntoIter instead of std (#707) - Paolo Barbolini
* | 4950c50 - (9 weeks ago) Offset from (#705) - Brad Dunbar
* | 86694b0 - (10 weeks ago) Add zero-copy make_mut (#695) - Émile Fugulin
* | 0c17e99 - (10 weeks ago) ci: silence unexpected-cfgs warnings due to `#[cfg(loom)]` (#703) - Alice Ryhl
* | cb7f844 - (3 months ago) Tweak clear and truncate length modifications (#700) - Alice Ryhl
* | a8806c2 - (3 months ago) Improve BytesMut::split suggestion (#699) - Paolo Barbolini
* | baa5053 - (3 months ago) Reuse capacity when possible in <BytesMut as Buf>::advance impl (#698) - Paolo Barbolini
* | ce09d7d - (3 months ago) Bytes::split_off - check fast path first (#693) - Brad Dunbar
* | 9d3ec1c - (3 months ago) Resize refactor (#696) - Brad Dunbar
* | 4e2c9c0 - (3 months ago) Truncate tweaks (#694) - Brad Dunbar
* | 327615e - (3 months ago) test(benches): encloses bytes into `test::black_box` for clone benches (#691) - Joseph Perez
* | b5fbfc3 - (3 months ago) perf: improve Bytes::copy_to_bytes (#688) - tison
* | 4eb62b9 - (3 months ago) Bytes::split_to - check fast path first (#689) - Brad Dunbar
* | e4af486 - (3 months ago) Don't set `len` in `BytesMut::reserve` (#682) - Brad Dunbar
* | 0d4cc7f - (3 months ago) Bytes: Use ManuallyDrop instead of mem::forget (#678) - Brad Dunbar
|/
* ce8d8a0 - (4 months ago) chore: prepare bytes v1.6.0 (#681) - Brad Dunbar (tag: v1.6.0)
```