### PR TITLE
chore: prepare bytes v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.7.1 (August 1, 2024)
+
+This release reverts the following change due to a regression:
+
+- Reuse capacity when possible in `<BytesMut as Buf>::advance` impl (#698)
+
+The revert can be found at #726.
+
 # 1.7.0 (July 31, 2024)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bytes"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.7.0"
+version = "1.7.1"
 edition = "2018"
 rust-version = "1.39"
 license = "MIT"


### PR DESCRIPTION
# 1.7.1 (August 1, 2024)

This release reverts the following change due to a regression:

- Reuse capacity when possible in `<BytesMut as Buf>::advance` impl (#698)

The revert can be found at #726.

