### PR TITLE
Fix double spaces in comments and doc comments

### DIFF
--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -1107,7 +1107,7 @@ pub unsafe trait BufMut {
         }
     }
 
-    /// Writes  an IEEE754 single-precision (4 bytes) floating point number to
+    /// Writes an IEEE754 single-precision (4 bytes) floating point number to
     /// `self` in big-endian byte order.
     ///
     /// The current position is advanced by 4.
@@ -1131,7 +1131,7 @@ pub unsafe trait BufMut {
         self.put_u32(n.to_bits());
     }
 
-    /// Writes  an IEEE754 single-precision (4 bytes) floating point number to
+    /// Writes an IEEE754 single-precision (4 bytes) floating point number to
     /// `self` in little-endian byte order.
     ///
     /// The current position is advanced by 4.
@@ -1183,7 +1183,7 @@ pub unsafe trait BufMut {
         self.put_u32_ne(n.to_bits());
     }
 
-    /// Writes  an IEEE754 double-precision (8 bytes) floating point number to
+    /// Writes an IEEE754 double-precision (8 bytes) floating point number to
     /// `self` in big-endian byte order.
     ///
     /// The current position is advanced by 8.
@@ -1207,7 +1207,7 @@ pub unsafe trait BufMut {
         self.put_u64(n.to_bits());
     }
 
-    /// Writes  an IEEE754 double-precision (8 bytes) floating point number to
+    /// Writes an IEEE754 double-precision (8 bytes) floating point number to
     /// `self` in little-endian byte order.
     ///
     /// The current position is advanced by 8.
@@ -1231,7 +1231,7 @@ pub unsafe trait BufMut {
         self.put_u64_le(n.to_bits());
     }
 
-    /// Writes  an IEEE754 double-precision (8 bytes) floating point number to
+    /// Writes an IEEE754 double-precision (8 bytes) floating point number to
     /// `self` in native-endian byte order.
     ///
     /// The current position is advanced by 8.

--- a/src/buf/uninit_slice.rs
+++ b/src/buf/uninit_slice.rs
@@ -110,7 +110,7 @@ impl UninitSlice {
         unsafe { self[index..].as_mut_ptr().write(byte) }
     }
 
-    /// Copies bytes  from `src` into `self`.
+    /// Copies bytes from `src` into `self`.
     ///
     /// The length of `src` must be the same as `self`.
     ///

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1301,7 +1301,7 @@ unsafe fn shallow_clone_vec(
     offset: *const u8,
     len: usize,
 ) -> Bytes {
-    // If  the buffer is still tracked in a `Vec<u8>`. It is time to
+    // If the buffer is still tracked in a `Vec<u8>`. It is time to
     // promote the vec to an `Arc`. This could potentially be called
     // concurrently, so some care must be taken.
 


### PR DESCRIPTION
Caught by this very naive regex: `[a-zA-Z0-9]  [a-zA-Z0-9]`