### PR TITLE
Example does not match "IntoIter::new"

### DIFF
--- a/src/buf/iter.rs
+++ b/src/buf/iter.rs
@@ -28,10 +28,10 @@ impl<T> IntoIter<T> {
     /// # Examples
     ///
     /// ```
-    /// use bytes::Bytes;
+    /// use bytes::{buf::IntoIter, Bytes};
     ///
     /// let buf = Bytes::from_static(b"abc");
-    /// let mut iter = buf.into_iter();
+    /// let mut iter = IntoIter::new(buf);
     ///
     /// assert_eq!(iter.next(), Some(b'a'));
     /// assert_eq!(iter.next(), Some(b'b'));


### PR DESCRIPTION
I think the below should be modified

from 

/// ```
/// use bytes::Bytes;
///
/// let buf = Bytes::from_static(b"abc");
/// let mut iter = buf.into_iter();
///
/// assert_eq!(iter.next(), Some(b'a'));
/// assert_eq!(iter.next(), Some(b'b'));
/// assert_eq!(iter.next(), Some(b'c'));
/// assert_eq!(iter.next(), None);
/// ```

to

/// ```
/// use bytes::{buf::IntoIter, Bytes};
///
/// let buf = Bytes::from_static(b"abc");
/// let mut iter = IntoIter::new(buf);
///
/// assert_eq!(iter.next(), Some(b'a'));
/// assert_eq!(iter.next(), Some(b'b'));
/// assert_eq!(iter.next(), Some(b'c'));
/// assert_eq!(iter.next(), None);
/// ```