### PR TITLE
ci: update nightly to nightly-2024-09-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  nightly: nightly-2022-11-12
+  nightly: nightly-2024-09-15
 
 defaults:
   run:
@@ -136,6 +136,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update $nightly && rustup default $nightly
       - name: Miri
         run: ci/miri.sh
 
@@ -160,6 +162,7 @@ jobs:
       - minrust
       - cross
       - tsan
+      - miri
       - loom
     runs-on: ubuntu-latest
     steps:

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-rustup toolchain install nightly --component miri
-rustup override set nightly
+rustup component add miri
 cargo miri setup
 
 export MIRIFLAGS="-Zmiri-strict-provenance"

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -142,6 +142,7 @@ impl Bytes {
         Bytes::from_static(EMPTY)
     }
 
+    /// Creates a new empty `Bytes`.
     #[cfg(all(loom, test))]
     pub fn new() -> Self {
         const EMPTY: &[u8] = &[];
@@ -172,6 +173,7 @@ impl Bytes {
         }
     }
 
+    /// Creates a new `Bytes` from a static slice.
     #[cfg(all(loom, test))]
     pub fn from_static(bytes: &'static [u8]) -> Self {
         Bytes {


### PR DESCRIPTION
This fixes CI failure: https://github.com/tokio-rs/bytes/actions/runs/10867401770/job/30156111363

Also, this changes miri test in CI to use the pinned nightly toolchain.