### PR TITLE
chore: prepare bytes v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 1.7.2 (September 17, 2024)
+
+### Fixed
+
+- Fix default impl of `Buf::{get_int, get_int_le}` (#732)
+
+### Documented
+
+- Fix double spaces in comments and doc comments (#731)
+
+### Internal changes
+
+- Ensure BytesMut::advance reduces capacity (#728) 
+
 # 1.7.1 (August 1, 2024)
 
 This release reverts the following change due to a regression:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bytes"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.7.1"
+version = "1.7.2"
 edition = "2018"
 rust-version = "1.39"
 license = "MIT"


### PR DESCRIPTION
# 1.7.2 (September 17, 2024)

### Fixed

- Fix default impl of `Buf::{get_int, get_int_le}` (#732)

### Documented

- Fix double spaces in comments and doc comments (#731)

### Internal changes

- Ensure BytesMut::advance reduces capacity (#728) 