### PR TITLE
Remove the `Vec` representation

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/loom.rs
+++ b/src/loom.rs
@@ -1,30 +1,13 @@
 #[cfg(not(all(test, loom)))]
 pub(crate) mod sync {
     pub(crate) mod atomic {
-        pub(crate) use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
-
-        pub(crate) trait AtomicMut<T> {
-            fn with_mut<F, R>(&mut self, f: F) -> R
-            where
-                F: FnOnce(&mut *mut T) -> R;
-        }
-
-        impl<T> AtomicMut<T> for AtomicPtr<T> {
-            fn with_mut<F, R>(&mut self, f: F) -> R
-            where
-                F: FnOnce(&mut *mut T) -> R,
-            {
-                f(self.get_mut())
-            }
-        }
+        pub(crate) use core::sync::atomic::{AtomicUsize, Ordering};
     }
 }
 
 #[cfg(all(test, loom))]
 pub(crate) mod sync {
     pub(crate) mod atomic {
-        pub(crate) use loom::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
-
-        pub(crate) trait AtomicMut<T> {}
+        pub(crate) use loom::sync::atomic::{AtomicUsize, Ordering};
     }
 }

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -130,6 +130,10 @@ fn do_test_slice_large<T: ?Sized>(make: impl Fn(&mut [u8]) -> &mut T)
 where
     for<'r> &'r mut T: BufMut,
 {
+    if cfg!(miri) {
+        return;
+    }
+
     const LEN: usize = 100;
     const FILL: [u8; LEN] = [b'Y'; LEN];
 


### PR DESCRIPTION
`Bytes` currently has both a “Vec” and “shared” representation, lazily upgrading the former to the latter. I believe that originally, the “Vec” representation allowed for excess capacity, but now it only works when `len == cap`. Given that it only saves one heap allocation, which is probably made anyway most of the time (it’s made whenever one does `.split`, `.truncate`, `.clone` etc), I would like to know how worth it it actually is.

The main benefit of removing it would probably be the removal of atomics, meaning it might have a bigger performance impact on ARM. But I don’t have an ARM machine, so if someone could run some benchmarks (Hyper or Tonic or something) on ARM – ideally multithreaded ones – that would be appreciated.

Maybe there’s a use case for this optimization I’m missing. I find that pretty rare to be using `Box<[u8]>` so I’m somewhat doubtful.

---

This PR is very much unfinished, I just creäted for initial feedback on the idea, and benchmarking purposes.