### PR TITLE
chore: prepare bytes v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.8.0 (October 21, 2024)
+
+- Guarantee address in `split_off`/`split_to` for empty slices (#740)
+
 # 1.7.2 (September 17, 2024)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bytes"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.7.2"
+version = "1.8.0"
 edition = "2018"
 rust-version = "1.39"
 license = "MIT"


### PR DESCRIPTION
# 1.8.0 (October 21, 2024)

- Guarantee address in `split_off`/`split_to` for empty slices (#740)

cc @joshlf