### PR TITLE
Rename hex_impl! to fmt_impl! and reuse it for fmt::Debug

### DIFF
--- a/src/fmt/debug.rs
+++ b/src/fmt/debug.rs
@@ -36,14 +36,5 @@ impl Debug for BytesRef<'_> {
     }
 }
 
-impl Debug for Bytes {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        Debug::fmt(&BytesRef(self.as_ref()), f)
-    }
-}
-
-impl Debug for BytesMut {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        Debug::fmt(&BytesRef(self.as_ref()), f)
-    }
-}
+fmt_impl!(Debug, Bytes);
+fmt_impl!(Debug, BytesMut);

--- a/src/fmt/hex.rs
+++ b/src/fmt/hex.rs
@@ -21,17 +21,7 @@ impl UpperHex for BytesRef<'_> {
     }
 }
 
-macro_rules! hex_impl {
-    ($tr:ident, $ty:ty) => {
-        impl $tr for $ty {
-            fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-                $tr::fmt(&BytesRef(self.as_ref()), f)
-            }
-        }
-    };
-}
-
-hex_impl!(LowerHex, Bytes);
-hex_impl!(LowerHex, BytesMut);
-hex_impl!(UpperHex, Bytes);
-hex_impl!(UpperHex, BytesMut);
+fmt_impl!(LowerHex, Bytes);
+fmt_impl!(LowerHex, BytesMut);
+fmt_impl!(UpperHex, Bytes);
+fmt_impl!(UpperHex, BytesMut);

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -8,9 +8,7 @@ macro_rules! fmt_impl {
     };
 }
 
-#[macro_use]
 mod debug;
-#[macro_use]
 mod hex;
 
 /// `BytesRef` is not a part of public API of bytes crate.

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -1,4 +1,16 @@
+macro_rules! fmt_impl {
+    ($tr:ident, $ty:ty) => {
+        impl $tr for $ty {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+                $tr::fmt(&BytesRef(self.as_ref()), f)
+            }
+        }
+    };
+}
+
+#[macro_use]
 mod debug;
+#[macro_use]
 mod hex;
 
 /// `BytesRef` is not a part of public API of bytes crate.


### PR DESCRIPTION
In `fmt` module there are two submodules:
* `debug` - Implementing `fmt::Debug`
* `hex` - Implementing `fmt::LowerHex`, `fmt::UpperHex`

Both implement core logic for `BytesRef<'_>`, but later one used a macro to propagate it to `Bytes` and `BytesMut` while other did it manually. This PR fixes that.

Macro imports in rust edition 2018 are limited. Therefore - I needed to first define a macro in a super module and later add `#[macro_use]` attribute to submodules.

I've tested that this solution does not leak the macro to the library public interface or docs.

Saves 9 lines of code ;) `16 insertions(+), 25 deletions(-)`