### PR TITLE
nit(docs): Fix typo in `Buf::chunk()` comment

### DIFF
--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -125,8 +125,8 @@ pub trait Buf {
     fn remaining(&self) -> usize;
 
     /// Returns a slice starting at the current position and of length between 0
-    /// and `Buf::remaining()`. Note that this *can* return shorter slice (this allows
-    /// non-continuous internal representation).
+    /// and `Buf::remaining()`. Note that this *can* return a shorter slice (this
+    /// allows non-continuous internal representation).
     ///
     /// This is a lower level function. Most operations are done with other
     /// functions.


### PR DESCRIPTION
This fixes a small grammar issue in the documentation.