### PR TITLE
Replace `BufMut::put` with `BufMut::put_slice` in Writer impl

### DIFF
--- a/src/buf/writer.rs
+++ b/src/buf/writer.rs
@@ -78,7 +78,7 @@ impl<B: BufMut + Sized> io::Write for Writer<B> {
     fn write(&mut self, src: &[u8]) -> io::Result<usize> {
         let n = cmp::min(self.buf.remaining_mut(), src.len());
 
-        self.buf.put(&src[0..n]);
+        self.buf.put_slice(&src[..n]);
         Ok(n)
     }
 


### PR DESCRIPTION
This makes the `Writer::write` implementation call `BufMut::put_slice` instead of going through `BufMut::put`, which has to handle non-contiguous `Buf`s.