### PR TITLE
Make `BytesMut::try_unsplit` method public

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -877,7 +877,8 @@ impl BytesMut {
         }
     }
 
-    /// Absorbs a `BytesMut` that was previously split off.
+    /// Absorbs a `BytesMut` that was previously split off if they are
+    /// contiguous, otherwise appends its bytes to this `BytesMut`.
     ///
     /// If the two `BytesMut` objects were previously contiguous and not mutated
     /// in a way that causes re-allocation i.e., if `other` was created by
@@ -990,7 +991,35 @@ impl BytesMut {
         self.cap -= count;
     }
 
-    fn try_unsplit(&mut self, other: BytesMut) -> Result<(), BytesMut> {
+    /// Absorbs a `BytesMut` that was previously split off.
+    ///
+    /// If the two `BytesMut` objects were previously contiguous, i.e., if
+    /// `other` was created by calling `split_off` on this `BytesMut`, then
+    /// this is an `O(1)` operation that just decreases a reference
+    /// count and sets a few indices. Otherwise this method returns an error
+    /// containing the original `other`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BytesMut;
+    ///
+    /// let mut buf = BytesMut::with_capacity(64);
+    /// buf.extend_from_slice(b"aaabbbcccddd");
+    ///
+    /// let mut split_1 = buf.split_off(3);
+    /// let split_2 = split_1.split_off(3);
+    /// assert_eq!(b"aaa", &buf[..]);
+    /// assert_eq!(b"bbb", &split_1[..]);
+    /// assert_eq!(b"cccddd", &split_2[..]);
+    ///
+    /// let split_2 = buf.try_unsplit(split_2).unwrap_err();
+    ///
+    /// buf.try_unsplit(split_1).unwrap();
+    /// buf.try_unsplit(split_2).unwrap();
+    /// assert_eq!(b"aaabbbcccddd", &buf[..]);
+    /// ```
+    pub fn try_unsplit(&mut self, other: BytesMut) -> Result<(), BytesMut> {
         if other.capacity() == 0 {
             return Ok(());
         }


### PR DESCRIPTION
This PR is identical diff-wise to #513 with some additional justification that hopefully leads to a merge. 

There are currently two open discussions. One is on whether the `Bytes` type should have a `try_unsplit` method and another one is on whether the `BytesMut` type should have a `try_unsplit` method. The former is being discussed in #287 and the latter in #702. 

The discussion on `Bytes` is complicated by the fact that the type does *not* currently have `unsplit` functionality. Therefore introducing it for that type is something to be considered deeply since it expands the surface area and comes with maintainability and backwards compatibility concerns.

This PR is **NOT** related to the `Bytes` type or that discussion.

This PR only changes `BytesMut` which already offers an `unsplit` method in its [public API](https://docs.rs/bytes/1.8.0/bytes/struct.BytesMut.html#method.unsplit) whose specification (i.e doc comment) is:

> Absorbs a `BytesMut` that was previously split off if they are contiguous, otherwise appends its bytes to this `BytesMut`.

This means that at least for `BytesMut` the unsplit functionality is here to stay, at least until a new major version is released. Also, the specification of `unsplit` already encodes this idea of "it will try to do X, otherwise fallback to Y" and so it is reasonable to expect that any future changes in the codebase will have to maintain this kind of conditional implementation where at some point the `unsplit` function makes a decision.

Under that view, all this PR is doing is offering what `unsplit` already does but without the "otherwise..." part, leaving it up to the user to select what happens next. This shouldn't present any backward compatibility/new surface concerns since no matter how `unsplit` evolves we can always take the logic until the `if possible_to_merge { .. }` bit and expose it under `try_unsplit`


