### PR TITLE
Prepare bytes v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@
 - Replace BufMut::put with BufMut::put_slice in Writer impl (#745)
 - Rename hex_impl! to fmt_impl! and reuse it for fmt::Debug (#743)
 
-
-
 # 1.8.0 (October 21, 2024)
 
 - Guarantee address in `split_off`/`split_to` for empty slices (#740)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 1.9.0 (November 27, 2024)
+
+### Added
+
+- Add `Bytes::from_owner` to enable externally-allocated memory (#742)
+
+### Documented
+
+- Fix typo in Buf::chunk() comment (#744)
+
+### Internal changes
+
+- Replace BufMut::put with BufMut::put_slice in Writer impl (#745)
+- Rename hex_impl! to fmt_impl! and reuse it for fmt::Debug (#743)
+
+
+
 # 1.8.0 (October 21, 2024)
 
 - Guarantee address in `split_off`/`split_to` for empty slices (#740)
@@ -14,7 +31,7 @@
 
 ### Internal changes
 
-- Ensure BytesMut::advance reduces capacity (#728) 
+- Ensure BytesMut::advance reduces capacity (#728)
 
 # 1.7.1 (August 1, 2024)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bytes"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.8.0"
+version = "1.9.0"
 edition = "2018"
 rust-version = "1.39"
 license = "MIT"


### PR DESCRIPTION
Ref https://github.com/tokio-rs/bytes/pull/742#issuecomment-2491268005.

A new release would be nice to take advantage of `Bytes::from_owner`