### PR TITLE
Support non-atomic targets by using portable-atomic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,26 @@ jobs:
           cargo build --target ${{ matrix.target }}
         if: matrix.target == 'wasm32-unknown-unknown'
 
+  # Build for no_std environment.
+  no-std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
+      # thumbv7m-none-eabi supports atomic CAS.
+      # thumbv6m-none-eabi supports atomic, but not atomic CAS.
+      - run: rustup target add thumbv7m-none-eabi
+      - run: rustup target add thumbv6m-none-eabi
+      # * --optional-deps is needed for serde feature
+      # * --no-dev-deps is needed to avoid https://github.com/rust-lang/cargo/issues/4866
+      - run: cargo hack build --target thumbv7m-none-eabi --feature-powerset --skip std,default --optional-deps --no-dev-deps
+      # A sound way to provide atomic CAS on platforms without native atomic CAS is system-dependent.
+      # portable-atomic provides major ways via cfgs and accepts user-defined implementations via critical-section feature.
+      - run: cargo hack build --target thumbv6m-none-eabi --feature-powerset --skip std,default --optional-deps --no-dev-deps --features extra-platforms,portable-atomic/critical-section
+
   # Sanitizers
   tsan:
     name: tsan

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,14 @@ categories = ["network-programming", "data-structures"]
 [features]
 default = ["std"]
 std = []
+# Use portable-atomic crate to support platforms without atomic CAS.
+# See https://docs.rs/portable-atomic for more information.
+extra-platforms = ["portable-atomic"]
 
 [dependencies]
 serde = { version = "1.0.60", optional = true, default-features = false, features = ["alloc"] }
+# Enable require-cas feature to provide a better error message if the end user forgets to use the cfg or feature.
+portable-atomic = { version = "1.10", optional = true, default-features = false, features = ["require-cas"] }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -16,7 +16,10 @@ if [[ "${RUST_VERSION}" == "nightly"* ]]; then
     cargo check --benches
 
     # Check minimal versions
-    cargo clean
-    cargo update -Zminimal-versions
+    # Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`
+    # from determining minimal versions based on dev-dependencies.
+    cargo hack --remove-dev-deps --workspace
+    # Update Cargo.lock to minimal version dependencies.
+    cargo update -Z minimal-versions
     cargo check --all-features
 fi

--- a/src/loom.rs
+++ b/src/loom.rs
@@ -1,7 +1,10 @@
 #[cfg(not(all(test, loom)))]
 pub(crate) mod sync {
     pub(crate) mod atomic {
+        #[cfg(not(feature = "extra-platforms"))]
         pub(crate) use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+        #[cfg(feature = "extra-platforms")]
+        pub(crate) use portable_atomic::{AtomicPtr, AtomicUsize, Ordering};
 
         pub(crate) trait AtomicMut<T> {
             fn with_mut<F, R>(&mut self, f: F) -> R


### PR DESCRIPTION
squashed commits from upstream #467 by @taiki-e and rebased with updated deps and resolved conflicts

I'm not sure this should be merged as-is because the original author would lose credit but given the comments on #467 I figured this was a useful exercise to see what else would be necessary to add before a merge could occur.