### PR TITLE
Try get methods for buf

### DIFF
--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -34,7 +34,7 @@ impl std::fmt::Display for TryGetError {
                 requested,
                 available,
             } => {
-                write!(f, "Not enough bytes remaining in buffer to read value (requested {requested} but only {available} available)")
+                write!(f, "Not enough bytes remaining in buffer to read value (requested {} but only {} available)", requested, available)
             }
         }
     }

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -3,8 +3,7 @@ use crate::buf::{reader, Reader};
 use crate::buf::{take, Chain, Take};
 #[cfg(feature = "std")]
 use crate::{min_u64_usize, saturating_sub_usize_u64};
-use crate::{panic_advance, panic_does_not_fit};
-use crate::Error;
+use crate::{panic_advance, panic_does_not_fit, Error};
 
 #[cfg(feature = "std")]
 use std::io::IoSlice;

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -2616,6 +2616,36 @@ macro_rules! deref_forward_buf {
         }
 
         #[inline]
+        fn get_u128(&mut self) -> u128 {
+            (**self).get_u128()
+        }
+
+        #[inline]
+        fn get_u128_le(&mut self) -> u128 {
+            (**self).get_u128_le()
+        }
+
+        #[inline]
+        fn get_u128_ne(&mut self) -> u128 {
+            (**self).get_u128_ne()
+        }
+
+        #[inline]
+        fn get_i128(&mut self) -> i128 {
+            (**self).get_i128()
+        }
+
+        #[inline]
+        fn get_i128_le(&mut self) -> i128 {
+            (**self).get_i128_le()
+        }
+
+        #[inline]
+        fn get_i128_ne(&mut self) -> i128 {
+            (**self).get_i128_ne()
+        }
+
+        #[inline]
         fn get_uint(&mut self, nbytes: usize) -> u64 {
             (**self).get_uint(nbytes)
         }
@@ -2643,6 +2673,231 @@ macro_rules! deref_forward_buf {
         #[inline]
         fn get_int_ne(&mut self, nbytes: usize) -> i64 {
             (**self).get_int_ne(nbytes)
+        }
+
+        #[inline]
+        fn get_f32(&mut self) -> f32 {
+            (**self).get_f32()
+        }
+
+        #[inline]
+        fn get_f32_le(&mut self) -> f32 {
+            (**self).get_f32_le()
+        }
+
+        #[inline]
+        fn get_f32_ne(&mut self) -> f32 {
+            (**self).get_f32_ne()
+        }
+
+        #[inline]
+        fn get_f64(&mut self) -> f64 {
+            (**self).get_f64()
+        }
+
+        #[inline]
+        fn get_f64_le(&mut self) -> f64 {
+            (**self).get_f64_le()
+        }
+
+        #[inline]
+        fn get_f64_ne(&mut self) -> f64 {
+            (**self).get_f64_ne()
+        }
+
+        #[inline]
+        fn try_copy_to_slice(&mut self, dst: &mut [u8]) -> Result<(), TryGetError> {
+            (**self).try_copy_to_slice(dst)
+        }
+
+        #[inline]
+        fn try_get_u8(&mut self) -> Result<u8, TryGetError> {
+            (**self).try_get_u8()
+        }
+
+        #[inline]
+        fn try_get_i8(&mut self) -> Result<i8, TryGetError> {
+            (**self).try_get_i8()
+        }
+
+        #[inline]
+        fn try_get_u16(&mut self) -> Result<u16, TryGetError> {
+            (**self).try_get_u16()
+        }
+
+        #[inline]
+        fn try_get_u16_le(&mut self) -> Result<u16, TryGetError> {
+            (**self).try_get_u16_le()
+        }
+
+        #[inline]
+        fn try_get_u16_ne(&mut self) -> Result<u16, TryGetError> {
+            (**self).try_get_u16_ne()
+        }
+
+        #[inline]
+        fn try_get_i16(&mut self) -> Result<i16, TryGetError> {
+            (**self).try_get_i16()
+        }
+
+        #[inline]
+        fn try_get_i16_le(&mut self) -> Result<i16, TryGetError> {
+            (**self).try_get_i16_le()
+        }
+
+        #[inline]
+        fn try_get_i16_ne(&mut self) -> Result<i16, TryGetError> {
+            (**self).try_get_i16_ne()
+        }
+
+        #[inline]
+        fn try_get_u32(&mut self) -> Result<u32, TryGetError> {
+            (**self).try_get_u32()
+        }
+
+        #[inline]
+        fn try_get_u32_le(&mut self) -> Result<u32, TryGetError> {
+            (**self).try_get_u32_le()
+        }
+
+        #[inline]
+        fn try_get_u32_ne(&mut self) -> Result<u32, TryGetError> {
+            (**self).try_get_u32_ne()
+        }
+
+        #[inline]
+        fn try_get_i32(&mut self) -> Result<i32, TryGetError> {
+            (**self).try_get_i32()
+        }
+
+        #[inline]
+        fn try_get_i32_le(&mut self) -> Result<i32, TryGetError> {
+            (**self).try_get_i32_le()
+        }
+
+        #[inline]
+        fn try_get_i32_ne(&mut self) -> Result<i32, TryGetError> {
+            (**self).try_get_i32_ne()
+        }
+
+        #[inline]
+        fn try_get_u64(&mut self) -> Result<u64, TryGetError> {
+            (**self).try_get_u64()
+        }
+
+        #[inline]
+        fn try_get_u64_le(&mut self) -> Result<u64, TryGetError> {
+            (**self).try_get_u64_le()
+        }
+
+        #[inline]
+        fn try_get_u64_ne(&mut self) -> Result<u64, TryGetError> {
+            (**self).try_get_u64_ne()
+        }
+
+        #[inline]
+        fn try_get_i64(&mut self) -> Result<i64, TryGetError> {
+            (**self).try_get_i64()
+        }
+
+        #[inline]
+        fn try_get_i64_le(&mut self) -> Result<i64, TryGetError> {
+            (**self).try_get_i64_le()
+        }
+
+        #[inline]
+        fn try_get_i64_ne(&mut self) -> Result<i64, TryGetError> {
+            (**self).try_get_i64_ne()
+        }
+
+        #[inline]
+        fn try_get_u128(&mut self) -> Result<u128, TryGetError> {
+            (**self).try_get_u128()
+        }
+
+        #[inline]
+        fn try_get_u128_le(&mut self) -> Result<u128, TryGetError> {
+            (**self).try_get_u128_le()
+        }
+
+        #[inline]
+        fn try_get_u128_ne(&mut self) -> Result<u128, TryGetError> {
+            (**self).try_get_u128_ne()
+        }
+
+        #[inline]
+        fn try_get_i128(&mut self) -> Result<i128, TryGetError> {
+            (**self).try_get_i128()
+        }
+
+        #[inline]
+        fn try_get_i128_le(&mut self) -> Result<i128, TryGetError> {
+            (**self).try_get_i128_le()
+        }
+
+        #[inline]
+        fn try_get_i128_ne(&mut self) -> Result<i128, TryGetError> {
+            (**self).try_get_i128_ne()
+        }
+
+        #[inline]
+        fn try_get_uint(&mut self, nbytes: usize) -> Result<u64, TryGetError> {
+            (**self).try_get_uint(nbytes)
+        }
+
+        #[inline]
+        fn try_get_uint_le(&mut self, nbytes: usize) -> Result<u64, TryGetError> {
+            (**self).try_get_uint_le(nbytes)
+        }
+
+        #[inline]
+        fn try_get_uint_ne(&mut self, nbytes: usize) -> Result<u64, TryGetError> {
+            (**self).try_get_uint_ne(nbytes)
+        }
+
+        #[inline]
+        fn try_get_int(&mut self, nbytes: usize) -> Result<i64, TryGetError> {
+            (**self).try_get_int(nbytes)
+        }
+
+        #[inline]
+        fn try_get_int_le(&mut self, nbytes: usize) -> Result<i64, TryGetError> {
+            (**self).try_get_int_le(nbytes)
+        }
+
+        #[inline]
+        fn try_get_int_ne(&mut self, nbytes: usize) -> Result<i64, TryGetError> {
+            (**self).try_get_int_ne(nbytes)
+        }
+
+        #[inline]
+        fn try_get_f32(&mut self) -> Result<f32, TryGetError> {
+            (**self).try_get_f32()
+        }
+
+        #[inline]
+        fn try_get_f32_le(&mut self) -> Result<f32, TryGetError> {
+            (**self).try_get_f32_le()
+        }
+
+        #[inline]
+        fn try_get_f32_ne(&mut self) -> Result<f32, TryGetError> {
+            (**self).try_get_f32_ne()
+        }
+
+        #[inline]
+        fn try_get_f64(&mut self) -> Result<f64, TryGetError> {
+            (**self).try_get_f64()
+        }
+
+        #[inline]
+        fn try_get_f64_le(&mut self) -> Result<f64, TryGetError> {
+            (**self).try_get_f64_le()
+        }
+
+        #[inline]
+        fn try_get_f64_ne(&mut self) -> Result<f64, TryGetError> {
+            (**self).try_get_f64_ne()
         }
 
         #[inline]

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -26,9 +26,8 @@ pub enum TryGetError {
     },
 }
 
-#[cfg(feature = "std")]
-impl std::fmt::Display for TryGetError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+impl core::fmt::Display for TryGetError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         match self {
             TryGetError::OutOfBytes {
                 requested,

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -11,7 +11,7 @@ use std::io::IoSlice;
 use alloc::boxed::Box;
 
 
-/// Error type for the `try_get_` methods in [`Buf`].
+/// Error type for the `try_get_` methods of [`Buf`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum TryGetError {
     /// Indicates that there were not enough remaining

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -914,7 +914,8 @@ pub trait Buf {
     ///
     /// # Panics
     ///
-    /// This function panics if there is not enough remaining data in `self`.
+    /// This function panics if there is not enough remaining data in `self`, or
+    /// if `nbytes` is greater than 8.
     fn get_uint(&mut self, nbytes: usize) -> u64 {
         buf_get_impl!(be => self, u64, nbytes);
     }
@@ -934,7 +935,8 @@ pub trait Buf {
     ///
     /// # Panics
     ///
-    /// This function panics if there is not enough remaining data in `self`.
+    /// This function panics if there is not enough remaining data in `self`, or
+    /// if `nbytes` is greater than 8.
     fn get_uint_le(&mut self, nbytes: usize) -> u64 {
         buf_get_impl!(le => self, u64, nbytes);
     }
@@ -1937,6 +1939,10 @@ pub trait Buf {
     /// let mut buf = &b"\x01\x02\x03"[..];
     /// assert_eq!(Err(Error::OutOfBytes), buf.try_get_uint(4));
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `nbytes` > 8.
     fn try_get_uint(&mut self, nbytes: usize) -> Result<u64, Error> {
         buf_try_get_impl!(be => self, u64, nbytes);
     }
@@ -1963,6 +1969,10 @@ pub trait Buf {
     /// let mut buf = &b"\x01\x02\x03"[..];
     /// assert_eq!(Err(Error::OutOfBytes), buf.try_get_uint_le(4));
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `nbytes` > 8.
     fn try_get_uint_le(&mut self, nbytes: usize) -> Result<u64, Error> {
         buf_try_get_impl!(le => self, u64, nbytes);
     }
@@ -1995,6 +2005,10 @@ pub trait Buf {
     /// };
     /// assert_eq!(Err(Error::OutOfBytes), buf.try_get_uint_ne(4));
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `nbytes` is greater than 8.
     fn try_get_uint_ne(&mut self, nbytes: usize) -> Result<u64, Error> {
         if cfg!(target_endian = "big") {
             self.try_get_uint(nbytes)
@@ -2025,6 +2039,10 @@ pub trait Buf {
     /// let mut buf = &b"\x01\x02\x03"[..];
     /// assert_eq!(Err(Error::OutOfBytes), buf.try_get_int(4));
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `nbytes` is greater than 8.
     fn try_get_int(&mut self, nbytes: usize) -> Result<i64, Error> {
         buf_try_get_impl!(be => self, i64, nbytes);
     }
@@ -2051,6 +2069,10 @@ pub trait Buf {
     /// let mut buf = &b"\x01\x02\x03"[..];
     /// assert_eq!(Err(Error::OutOfBytes), buf.try_get_int_le(4));
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `nbytes` is greater than 8.
     fn try_get_int_le(&mut self, nbytes: usize) -> Result<i64, Error> {
         buf_try_get_impl!(le => self, i64, nbytes);
     }
@@ -2083,6 +2105,10 @@ pub trait Buf {
     /// };
     /// assert_eq!(Err(Error::OutOfBytes), buf.try_get_int_ne(4));
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `nbytes` is greater than 8.
     fn try_get_int_ne(&mut self, nbytes: usize) -> Result<i64, Error> {
         if cfg!(target_endian = "big") {
             self.try_get_int(nbytes)

--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -10,7 +10,6 @@ use std::io::IoSlice;
 
 use alloc::boxed::Box;
 
-
 /// Error type for the `try_get_` methods of [`Buf`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum TryGetError {
@@ -25,14 +24,15 @@ pub enum TryGetError {
 impl std::fmt::Display for TryGetError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
-            TryGetError::OutOfBytes => write!(f, "Not enough bytes remaining in buffer to read value"),
+            TryGetError::OutOfBytes => {
+                write!(f, "Not enough bytes remaining in buffer to read value")
+            }
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for TryGetError {
-}
+impl std::error::Error for TryGetError {}
 
 macro_rules! buf_get_impl {
     ($this:ident, $typ:tt::$conv:tt) => {{

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -1,7 +1,7 @@
 use crate::buf::{limit, Chain, Limit, UninitSlice};
 #[cfg(feature = "std")]
 use crate::buf::{writer, Writer};
-use crate::{panic_advance, panic_does_not_fit};
+use crate::{panic_advance, panic_does_not_fit, TryGetError};
 
 use core::{mem, ptr, usize};
 
@@ -204,7 +204,10 @@ pub unsafe trait BufMut {
         Self: Sized,
     {
         if self.remaining_mut() < src.remaining() {
-            panic_advance(src.remaining(), self.remaining_mut());
+            panic_advance(&TryGetError {
+                requested: src.remaining(),
+                available: self.remaining_mut(),
+            });
         }
 
         while src.has_remaining() {
@@ -242,7 +245,10 @@ pub unsafe trait BufMut {
     #[inline]
     fn put_slice(&mut self, mut src: &[u8]) {
         if self.remaining_mut() < src.len() {
-            panic_advance(src.len(), self.remaining_mut());
+            panic_advance(&TryGetError {
+                requested: src.len(),
+                available: self.remaining_mut(),
+            });
         }
 
         while !src.is_empty() {
@@ -285,7 +291,10 @@ pub unsafe trait BufMut {
     #[inline]
     fn put_bytes(&mut self, val: u8, mut cnt: usize) {
         if self.remaining_mut() < cnt {
-            panic_advance(cnt, self.remaining_mut());
+            panic_advance(&TryGetError {
+                requested: cnt,
+                available: self.remaining_mut(),
+            })
         }
 
         while cnt > 0 {
@@ -1487,7 +1496,10 @@ unsafe impl BufMut for &mut [u8] {
     #[inline]
     unsafe fn advance_mut(&mut self, cnt: usize) {
         if self.len() < cnt {
-            panic_advance(cnt, self.len());
+            panic_advance(&TryGetError {
+                requested: cnt,
+                available: self.len(),
+            });
         }
 
         // Lifetime dance taken from `impl Write for &mut [u8]`.
@@ -1498,7 +1510,10 @@ unsafe impl BufMut for &mut [u8] {
     #[inline]
     fn put_slice(&mut self, src: &[u8]) {
         if self.len() < src.len() {
-            panic_advance(src.len(), self.len());
+            panic_advance(&TryGetError {
+                requested: src.len(),
+                available: self.len(),
+            });
         }
 
         self[..src.len()].copy_from_slice(src);
@@ -1509,7 +1524,10 @@ unsafe impl BufMut for &mut [u8] {
     #[inline]
     fn put_bytes(&mut self, val: u8, cnt: usize) {
         if self.len() < cnt {
-            panic_advance(cnt, self.len());
+            panic_advance(&TryGetError {
+                requested: cnt,
+                available: self.len(),
+            });
         }
 
         // SAFETY: We just checked that the pointer is valid for `cnt` bytes.
@@ -1534,7 +1552,10 @@ unsafe impl BufMut for &mut [core::mem::MaybeUninit<u8>] {
     #[inline]
     unsafe fn advance_mut(&mut self, cnt: usize) {
         if self.len() < cnt {
-            panic_advance(cnt, self.len());
+            panic_advance(&TryGetError {
+                requested: cnt,
+                available: self.len(),
+            });
         }
 
         // Lifetime dance taken from `impl Write for &mut [u8]`.
@@ -1545,7 +1566,10 @@ unsafe impl BufMut for &mut [core::mem::MaybeUninit<u8>] {
     #[inline]
     fn put_slice(&mut self, src: &[u8]) {
         if self.len() < src.len() {
-            panic_advance(src.len(), self.len());
+            panic_advance(&TryGetError {
+                requested: src.len(),
+                available: self.len(),
+            });
         }
 
         // SAFETY: We just checked that the pointer is valid for `src.len()` bytes.
@@ -1558,7 +1582,10 @@ unsafe impl BufMut for &mut [core::mem::MaybeUninit<u8>] {
     #[inline]
     fn put_bytes(&mut self, val: u8, cnt: usize) {
         if self.len() < cnt {
-            panic_advance(cnt, self.len());
+            panic_advance(&TryGetError {
+                requested: cnt,
+                available: self.len(),
+            });
         }
 
         // SAFETY: We just checked that the pointer is valid for `cnt` bytes.
@@ -1582,7 +1609,10 @@ unsafe impl BufMut for Vec<u8> {
         let remaining = self.capacity() - len;
 
         if remaining < cnt {
-            panic_advance(cnt, remaining);
+            panic_advance(&TryGetError {
+                requested: cnt,
+                available: remaining,
+            });
         }
 
         // Addition will not overflow since the sum is at most the capacity.

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -27,7 +27,7 @@ mod vec_deque;
 #[cfg(feature = "std")]
 mod writer;
 
-pub use self::buf_impl::{Buf, TryGetError};
+pub use self::buf_impl::Buf;
 pub use self::buf_mut::BufMut;
 pub use self::chain::Chain;
 pub use self::iter::IntoIter;

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -27,7 +27,7 @@ mod vec_deque;
 #[cfg(feature = "std")]
 mod writer;
 
-pub use self::buf_impl::Buf;
+pub use self::buf_impl::{Buf, TryGetError};
 pub use self::buf_mut::BufMut;
 pub use self::chain::Chain;
 pub use self::iter::IntoIter;

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -17,7 +17,7 @@ use crate::bytes::Vtable;
 #[allow(unused)]
 use crate::loom::sync::atomic::AtomicMut;
 use crate::loom::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
-use crate::{offset_from, Buf, BufMut, Bytes};
+use crate::{offset_from, Buf, BufMut, Bytes, TryGetError};
 
 /// A unique reference to a contiguous slice of memory.
 ///
@@ -1178,7 +1178,10 @@ unsafe impl BufMut for BytesMut {
     unsafe fn advance_mut(&mut self, cnt: usize) {
         let remaining = self.cap - self.len();
         if cnt > remaining {
-            super::panic_advance(cnt, remaining);
+            super::panic_advance(&TryGetError {
+                requested: cnt,
+                available: remaining,
+            });
         }
         // Addition won't overflow since it is at most `self.cap`.
         self.len = self.len() + cnt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod buf;
-pub use crate::buf::{Buf, BufMut};
+pub use crate::buf::{Buf, BufMut, TryGetError};
 
 mod bytes;
 mod bytes_mut;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod buf;
-pub use crate::buf::{Buf, BufMut};
+pub use crate::buf::{Buf, BufMut, TryGetError};
 
 mod bytes;
 mod bytes_mut;
@@ -162,27 +162,4 @@ fn panic_does_not_fit(size: usize, nbytes: usize) -> ! {
 #[inline]
 fn offset_from(dst: *const u8, original: *const u8) -> usize {
     dst as usize - original as usize
-}
-
-/// Error type for the Bytes crate.
-#[derive(Debug, PartialEq, Eq)]
-pub enum Error {
-    /// Indicates that there were not enough remaining
-    /// bytes in the buffer while attempting
-    /// to get a value from a [`Buf`] with one
-    /// of the `try_get_` methods.
-    OutOfBytes,
-}
-
-#[cfg(feature = "std")]
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        match self {
-            Error::OutOfBytes => write!(f, "Not enough bytes remaining in buffer to read value"),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ pub enum Error {
     OutOfBytes,
 }
 
+#[cfg(feature = "std")]
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod buf;
-pub use crate::buf::{Buf, BufMut, TryGetError};
+pub use crate::buf::{Buf, BufMut};
 
 mod bytes;
 mod bytes_mut;
@@ -132,12 +132,46 @@ fn min_u64_usize(a: u64, b: usize) -> usize {
     }
 }
 
+/// Error type for the `try_get_` methods of [`Buf`].
+/// Indicates that there were not enough remaining
+/// bytes in the buffer while attempting
+/// to get a value from a [`Buf`] with one
+/// of the `try_get_` methods.
+#[derive(Debug, PartialEq, Eq)]
+pub struct TryGetError {
+    /// The number of bytes necessary to get the value
+    pub requested: usize,
+
+    /// The number of bytes available in the buffer
+    pub available: usize,
+}
+
+impl core::fmt::Display for TryGetError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        write!(
+            f,
+            "Not enough bytes remaining in buffer to read value (requested {} but only {} available)",
+            self.requested,
+            self.available)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TryGetError {}
+
+#[cfg(feature = "std")]
+impl From<TryGetError> for std::io::Error {
+    fn from(error: TryGetError) -> Self {
+        std::io::Error::new(std::io::ErrorKind::Other, error)
+    }
+}
+
 /// Panic with a nice error message.
 #[cold]
-fn panic_advance(idx: usize, len: usize) -> ! {
+fn panic_advance(error_info: &TryGetError) -> ! {
     panic!(
         "advance out of bounds: the len is {} but advancing by {}",
-        len, idx
+        error_info.available, error_info.requested
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod buf;
-pub use crate::buf::{Buf, BufMut, TryGetError};
+pub use crate::buf::{Buf, BufMut};
 
 mod bytes;
 mod bytes_mut;
@@ -162,4 +162,26 @@ fn panic_does_not_fit(size: usize, nbytes: usize) -> ! {
 #[inline]
 fn offset_from(dst: *const u8, original: *const u8) -> usize {
     dst as usize - original as usize
+}
+
+/// Error type for the Bytes crate.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    /// Indicates that there were not enough remaining
+    /// bytes in the buffer while attempting
+    /// to get a value from a [`Buf`] with one
+    /// of the `try_get_` methods.
+    OutOfBytes,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            Error::OutOfBytes => write!(f, "Not enough bytes remaining in buffer to read value"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,8 @@ impl core::fmt::Display for TryGetError {
             f,
             "Not enough bytes remaining in buffer to read value (requested {} but only {} available)",
             self.requested,
-            self.available)
+            self.available
+        )
     }
 }
 


### PR DESCRIPTION
Adds fallible `try_get_` methods to Buf. The methods align with the existing `get_` methods.  All of them, so this is a lot of lines but most of it is documentation.  Note that I copied and adapted `buf_get_impl` to make `try_buf_get_impl`.  It is possible to avoid some code duplication by calling `buf_get_impl` instead, but that will checked the remaining bytes twice, and `buf_get_impl` is performance optimized so I chose not to do that.

This code borrows some from the existing PR for this feature by @caelunshun, but that is old with lots of conflicts, so I chose to reimplement it from the current master instead.

I would rater have used from_be_bytes etc. for the floats as that seems more portable for NaN values, but it seems that the supported rust version is perhaps one minor version too old for that.

Closes #254 