### PR TITLE
Disable test_bytes_vec_alloc test on miri

### DIFF
--- a/tests/test_bytes_vec_alloc.rs
+++ b/tests/test_bytes_vec_alloc.rs
@@ -1,3 +1,4 @@
+#![cfg(not(miri))]
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};


### PR DESCRIPTION
The miri job takes >3 hours to run because of this file. This is since #749 that increased the size of the ledger.