### PR TITLE
Use [lints] to address unexpected_cfgs lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,8 @@ loom = "0.7"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(loom)',
+] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,


### PR DESCRIPTION
Same as https://github.com/tokio-rs/tokio/pull/7124.

Closes #704
