### PR TITLE
ci: test AArch64 Linux and run tests instead of build in cross job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - ubuntu-22.04-arm # TODO: update to 24.04 when https://github.com/rust-lang/rust/issues/135867 solved
           - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
@@ -104,29 +105,27 @@ jobs:
     name: cross
     strategy:
       matrix:
-        target:
-          - i686-unknown-linux-gnu
-          - armv7-unknown-linux-gnueabihf
-          - powerpc-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
-          - wasm32-unknown-unknown
-    runs-on: ubuntu-latest
+        include:
+          - target: i686-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: armv7-unknown-linux-gnueabihf
+            os: ubuntu-22.04-arm # TODO: update to 24.04 when https://github.com/rust-lang/rust/issues/135867 solved
+          - target: powerpc-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: powerpc64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: wasm32-wasip1
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update stable
-      - name: Install cross
-        uses: taiki-e/install-action@cross
-        if: matrix.target != 'wasm32-unknown-unknown'
-      - name: cross build --target ${{ matrix.target }}
-        run: cross build --target ${{ matrix.target }}
-        if: matrix.target != 'wasm32-unknown-unknown'
-      # WASM support
-      - name: cargo build --target ${{ matrix.target }}
-        run: |
-          rustup target add ${{ matrix.target }}
-          cargo build --target ${{ matrix.target }}
-        if: matrix.target == 'wasm32-unknown-unknown'
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+      - name: Test
+        run: cargo test --target ${{ matrix.target }}
 
   # Sanitizers
   tsan:

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -728,6 +728,7 @@ fn advance_past_len() {
 // Only run these tests on little endian systems. CI uses qemu for testing
 // big endian... and qemu doesn't really support threading all that well.
 #[cfg(any(miri, target_endian = "little"))]
+#[cfg(not(target_family = "wasm"))] // wasm without experimental threads proposal doesn't support threads
 fn stress() {
     // Tests promoting a buffer from a vec -> shared in a concurrent situation
     use std::sync::{Arc, Barrier};


### PR DESCRIPTION
## Motivation

Currently, "cross" job in our CI is build-only and doesn't run tests:

https://github.com/tokio-rs/bytes/blob/3ab876fee66393b064c2adac83d28fca46186075/.github/workflows/ci.yml#L121-L129

And AArch64 Linux which is tier1 in rustc is not tested.

https://github.com/tokio-rs/bytes/blob/3ab876fee66393b064c2adac83d28fca46186075/.github/workflows/ci.yml#L106-L113

## Solution

This PR adds `aarc64-unknown-linux-gnu` (ubuntu-22.04-arm) to matrix of tests on stable ("stable" job), and update "cross" job to run tests by using setup-cross-toolchain-action which is used in tokio. (see also https://github.com/tokio-rs/tokio/pull/7123 for AArch64/Armv7hf)

As for WASM testing, use `wasm32-wasip1` instead of `wasm32-unknown-unknown` because `wasm32-wasip1` can test with `cargo test` command. (Testing `wasm32-unknown-unknown` usually needs `wasm-pack` or other commands.)