### PR TITLE
Memory leak in owned_to_vec

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1162,7 +1162,7 @@ unsafe fn owned_drop_impl(owned: *mut ()) {
 
     let old_cnt = ref_cnt.fetch_sub(1, Ordering::Release);
     debug_assert!(
-        old_cnt > 0 && old_cnt < usize::MAX >> 1,
+        old_cnt > 0 && old_cnt <= usize::MAX >> 1,
         "expected non-zero refcount and no underflow"
     );
     if old_cnt != 1 {

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1141,9 +1141,11 @@ unsafe fn owned_clone(data: &AtomicPtr<()>, ptr: *const u8, len: usize) -> Bytes
     }
 }
 
-unsafe fn owned_to_vec(_data: &AtomicPtr<()>, ptr: *const u8, len: usize) -> Vec<u8> {
+unsafe fn owned_to_vec(data: &AtomicPtr<()>, ptr: *const u8, len: usize) -> Vec<u8> {
     let slice = slice::from_raw_parts(ptr, len);
-    slice.to_vec()
+    let vec = slice.to_vec();
+    owned_drop_impl(data.load(Ordering::Relaxed));
+    vec
 }
 
 unsafe fn owned_to_mut(data: &AtomicPtr<()>, ptr: *const u8, len: usize) -> BytesMut {

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1620,6 +1620,20 @@ fn owned_to_vec() {
 }
 
 #[test]
+fn owned_into_vec() {
+    let drop_counter = SharedAtomicCounter::new();
+    {
+        let buf: [u8; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let owner = OwnedTester::new(buf, drop_counter.clone());
+        let b1 = Bytes::from_owner(owner);
+
+        let v1: Vec<u8> = b1.into();
+        assert_eq!(&v1[..], &buf[..]);
+    }
+    assert_eq!(drop_counter.get(), 1);
+}
+
+#[test]
 #[cfg_attr(not(panic = "unwind"), ignore)]
 fn owned_safe_drop_on_as_ref_panic() {
     let buf: [u8; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1622,14 +1622,13 @@ fn owned_to_vec() {
 #[test]
 fn owned_into_vec() {
     let drop_counter = SharedAtomicCounter::new();
-    {
-        let buf: [u8; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let owner = OwnedTester::new(buf, drop_counter.clone());
-        let b1 = Bytes::from_owner(owner);
+    let buf: [u8; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let owner = OwnedTester::new(buf, drop_counter.clone());
+    let b1 = Bytes::from_owner(owner);
 
-        let v1: Vec<u8> = b1.into();
-        assert_eq!(&v1[..], &buf[..]);
-    }
+    let v1: Vec<u8> = b1.into();
+    assert_eq!(&v1[..], &buf[..]);
+    // into() vec will copy out of the owner and drop it
     assert_eq!(drop_counter.get(), 1);
 }
 


### PR DESCRIPTION
The following sequence:

```rust
    let b1 = Bytes::from_owner(owner);
    let v1: Vec<u8> = b1.into();
```

Would fail to drop `owner` (the expectation for the vtable *_to_vec is that it takes ownership of the instance, but owned_to_vec was not).  Since owned_to_mut depended on owned_to_vec and was correctly dropping, the fix was to move the drop logic from owned_to_mut to owned_to_vec.

This change adds an appropriate test for ::into() for Bytes::from_owner.