### PR TITLE
chore: prepare bytes v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.10.1 (March 5th, 2025)
+
+### Fixed
+
+- Fix memory leak when using `to_vec` with `Bytes::from_owner` (#773)
+
 # 1.10.0 (February 3rd, 2025)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bytes"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.10.0"
+version = "1.10.1"
 edition = "2018"
 rust-version = "1.39"
 license = "MIT"


### PR DESCRIPTION
# 1.10.1 (March 5th, 2025)

### Fixed

- Fix memory leak when using `to_vec` with `Bytes::from_owner` ([#773])

[#773]: https://github.com/tokio-rs/bytes/pull/773

