### PR TITLE
rename `Vtable::to_*` -> `Vtable::into_*`

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1776,8 +1776,8 @@ unsafe fn rebuild_vec(ptr: *mut u8, mut len: usize, mut cap: usize, off: usize) 
 
 static SHARED_VTABLE: Vtable = Vtable {
     clone: shared_v_clone,
-    to_vec: shared_v_to_vec,
-    to_mut: shared_v_to_mut,
+    into_vec: shared_v_to_vec,
+    into_mut: shared_v_to_mut,
     is_unique: shared_v_is_unique,
     drop: shared_v_drop,
 };


### PR DESCRIPTION
The new name matches the Rust convention for methods that consume `self`, as referred to in the following clippy lint: <https://rust-lang.github.io/rust-clippy/stable/index.html#wrong_self_convention> This may help avoid bugs such as that fixed in #773.