### PR TITLE
Add some tests for Limit, BytesMut and Reader

### DIFF
--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -187,6 +187,13 @@ fn split_off_oob() {
 }
 
 #[test]
+#[should_panic]
+fn bytes_mut_split_off_oob() {
+    let mut hello = BytesMut::from(&b"helloworld"[..]);
+    let _ = hello.split_off(44);
+}
+
+#[test]
 fn split_off_uninitialized() {
     let mut bytes = BytesMut::with_capacity(1024);
     let other = bytes.split_off(128);

--- a/tests/test_limit.rs
+++ b/tests/test_limit.rs
@@ -1,0 +1,86 @@
+#![warn(rust_2018_idioms)]
+
+use bytes::{buf::Limit, BufMut};
+
+#[test]
+fn long_limit() {
+    let buf = &mut [0u8; 10];
+    let limit = buf.limit(100);
+    assert_eq!(10, limit.remaining_mut());
+    assert_eq!(&[0u8; 10], &limit.get_ref()[..]);
+}
+
+#[test]
+fn limit_get_mut() {
+    let buf = &mut [0u8; 128];
+    let mut limit = buf.limit(10);
+    assert_eq!(10, limit.remaining_mut());
+    assert_eq!(&mut [0u8; 128], &limit.get_mut()[..]);
+}
+
+#[test]
+fn limit_set_limit() {
+    let buf = &mut [0u8; 128];
+    let mut limit = buf.limit(10);
+    assert_eq!(10, Limit::limit(&limit));
+    limit.set_limit(5);
+    assert_eq!(5, Limit::limit(&limit));
+}
+
+#[test]
+fn limit_chunk_mut() {
+    let buf = &mut [0u8; 20];
+    let mut limit = buf.limit(10);
+    assert_eq!(10, limit.chunk_mut().len());
+
+    let buf = &mut [0u8; 10];
+    let mut limit = buf.limit(20);
+    assert_eq!(10, limit.chunk_mut().len());
+}
+
+#[test]
+#[should_panic]
+fn limit_advanve_mut_panic_1() {
+    let buf = &mut [0u8; 10];
+    let mut limit = buf.limit(100);
+    unsafe {
+        limit.advance_mut(50);
+    }
+}
+
+#[test]
+#[should_panic]
+fn limit_advanve_mut_panic_2() {
+    let buf = &mut [0u8; 100];
+    let mut limit = buf.limit(10);
+    unsafe {
+        limit.advance_mut(50);
+    }
+}
+
+#[test]
+fn limit_advance_mut() {
+    let buf = &mut [0u8; 100];
+    let mut limit = buf.limit(10);
+    unsafe {
+        limit.advance_mut(5);
+    }
+    assert_eq!(5, limit.remaining_mut());
+    assert_eq!(5, limit.chunk_mut().len());
+}
+
+#[test]
+fn limit_into_inner() {
+    let buf_arr = *b"hello world";
+    let buf: &mut [u8] = &mut buf_arr.clone();
+    let mut limit = buf.limit(4);
+    let mut dst = vec![];
+
+    unsafe {
+        limit.advance_mut(2);
+    }
+
+    let buf = limit.into_inner();
+    dst.put(&buf[..]);
+    assert_eq!(*dst, b"llo world"[..]);
+}

--- a/tests/test_reader.rs
+++ b/tests/test_reader.rs
@@ -27,3 +27,12 @@ fn buf_read() {
     reader.read_line(&mut line).unwrap();
     assert_eq!("world", &line);
 }
+
+#[test]
+fn get_mut() {
+    let buf = &b"hello world"[..];
+    let mut reader = buf.reader();
+    let buf_mut = reader.get_mut();
+    assert_eq!(11, buf_mut.remaining());
+    assert_eq!(b"hello world", buf_mut);
+}


### PR DESCRIPTION
Hi,

Thanks for your time to review this PR.

By examing the existing code, we found that some tests can be added to improve the repo's overall test coverage. The tests we submitted have been carefully curated by us to ensure their behavior and effectiveness.
The code region we covered is:
limit.rs:
[limit.rs](https://github.com/tokio-rs/bytes/blob/d9d5c59ef81038d7b50f61c4250a132c2f5dc91c/src/buf/limit.rs)

reader.rs:
https://github.com/tokio-rs/bytes/blob/d9d5c59ef81038d7b50f61c4250a132c2f5dc91c/src/buf/reader.rs#L40-L42

bytes_mut.rs:
https://github.com/tokio-rs/bytes/blob/d9d5c59ef81038d7b50f61c4250a132c2f5dc91c/src/bytes_mut.rs#L323-L325

And while testing the Limit implementation, I noticed that when both Limit and BytesMut are introduced, calling the limit method on a Limit<&mut [u8]> object would by default invoke the limit method from BytesMut. This behavior seems somewhat counterintuitive to me. I'm not certain whether this needs to be addressed, but I thought I'd mention it for awareness.
[link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=30c689cf8ff0e86d9f101cdbf2be852c)

Thanks again for reviewing.
