### PR TITLE
Ignore BytesMut::freeze doctest on wasm

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -225,7 +225,7 @@ impl BytesMut {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use bytes::{BytesMut, BufMut};
     /// use std::thread;
     ///


### PR DESCRIPTION
Fix CI failure at the master branch: https://github.com/tokio-rs/bytes/actions/runs/16856445081

See https://github.com/drager/wasm-pack/issues/1518#issuecomment-3172337213 for details.