### PR TITLE
Reserve capacity in BytesMut::put

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1210,6 +1210,9 @@ unsafe impl BufMut for BytesMut {
                 Err(bytes) => self.extend_from_slice(&bytes),
             }
         } else {
+            // In case the src isn't contiguous, reserve upfront.
+            self.reserve(src.remaining());
+
             while src.has_remaining() {
                 let s = src.chunk();
                 let l = s.len();


### PR DESCRIPTION
Copy-paste code from `Vec::put`
https://github.com/tokio-rs/bytes/blob/3e44f88f5fae6dfcd3aa0779b804b3ff18afdee3/src/buf/buf_mut.rs#L1645-L1646