### PR TITLE
Tweak BytesMut::remaining_mut

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1170,7 +1170,8 @@ impl Buf for BytesMut {
 unsafe impl BufMut for BytesMut {
     #[inline]
     fn remaining_mut(&self) -> usize {
-        usize::MAX - self.len()
+        // Max allocation size is isize::MAX.
+        isize::MAX as usize - self.len()
     }
 
     #[inline]


### PR DESCRIPTION
Same as in `Vec`: max allocation size in Rust is `isize::MAX`.

https://github.com/tokio-rs/bytes/blob/3e44f88f5fae6dfcd3aa0779b804b3ff18afdee3/src/buf/buf_mut.rs#L1601-L1604