### PR TITLE
Document that `BytesMut::{reserve,try_reserve}` doesn't preserve unused capacity

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -551,6 +551,8 @@ impl BytesMut {
     /// and the original buffer is large enough to fit the requested additional
     /// capacity, then reallocations will never happen.
     ///
+    /// This method does not preserve data stored in the unused capacity.
+    ///
     /// # Examples
     ///
     /// In the following example, a new buffer is allocated.
@@ -796,6 +798,8 @@ impl BytesMut {
     /// Reclaiming the allocation cheaply is possible if the `BytesMut` has no outstanding
     /// references through other `BytesMut`s or `Bytes` which point to the same underlying
     /// storage.
+    ///
+    /// This method does not preserve data stored in the unused capacity.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This documents that `BytesMut` may not preserve the memory outside of `0..len` after calling `BytesMut::reserve`. It may for example discard all of it, and replace it with uninit memory in the [fallback case](https://github.com/tokio-rs/bytes/blob/acd1e0ffb8f076225759b8005d04f65ef77cccca/src/bytes_mut.rs#L767-L780), or even shift it causing a different region of the `BytesMut` to appear when going through the [reclaim optimization](https://github.com/tokio-rs/bytes/blob/acd1e0ffb8f076225759b8005d04f65ef77cccca/src/bytes_mut.rs#L685-L711).

This was encountered in https://github.com/snapview/tungstenite-rs/pull/524#discussion_r2554375051 after #805 was closed, which could have lead to unsound code being merged into `tungstenite`.

