### PR TITLE
chore(ci): add Renovate config for keeping pinned nightly version up-to-date

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   // Only enable regex manager - disables all default managers (cargo, npm, etc.)
   "enabledManagers": ["regex"],
   "schedule": ["on the first day of the month"],
+  "semanticCommits": "enabled",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
i noticed that the nightly version pinned in CI is out of date.

I'm all for pinning toolchain versions, but this introduces a risk that they stagnate.

automatically updating it at regular intervals gives you the best of both worlds- consistent, pinned behaviour and no stagnation.

this requires enabling Renovate for the repo, which requires input and buy-in from the maintainers. Note that i've restricted Renovate to operate *only* on this pinned toolchain version, but it could be used for bumping cargo and action dependencies as well if desired.