### PR TITLE
Introduce Cursor and CursorMut traits

### DIFF
--- a/src/buf/chain.rs
+++ b/src/buf/chain.rs
@@ -1,5 +1,5 @@
 use crate::buf::{IntoIter, UninitSlice};
-use crate::{Buf, BufMut};
+use crate::{Buf, BufMut, Cursor, CursorMut};
 
 #[cfg(feature = "std")]
 use std::io::IoSlice;
@@ -223,6 +223,33 @@ where
         }
 
         self.b.advance_mut(cnt);
+    }
+}
+
+impl<T: Cursor, U: Cursor> Cursor for Chain<T, U> {
+    type Cursor<'a>
+        = Chain<T::Cursor<'a>, U::Cursor<'a>>
+    where
+        Self: 'a;
+
+    fn cursor(&self, index: usize) -> Self::Cursor<'_> {
+        let mut chain = self.a.cursor(0).chain(self.b.cursor(0));
+        chain.advance(index);
+        chain
+    }
+}
+
+unsafe impl<T: CursorMut, U: CursorMut> CursorMut for Chain<T, U> {
+    type CursorMut<'a>
+        = Chain<T::CursorMut<'a>, U::CursorMut<'a>>
+    where
+        Self: 'a;
+
+    fn cursor_mut(&mut self, index: usize) -> Self::CursorMut<'_> {
+        let mut chain = self.a.cursor_mut(0).chain_mut(self.b.cursor_mut(0));
+        // SAFETY: advance_mut must be safe on CursorMut::CursorMut
+        unsafe { chain.advance_mut(index) };
+        chain
     }
 }
 

--- a/src/buf/cursor.rs
+++ b/src/buf/cursor.rs
@@ -1,0 +1,35 @@
+use crate::{buf::Chain, Buf};
+use std::collections::VecDeque;
+
+pub trait Cursor: Buf {
+    type Cursor<'a>: Buf
+    where
+        Self: 'a;
+
+    fn cursor(&self, index: usize) -> Self::Cursor<'_>;
+}
+
+impl Cursor for &[u8] {
+    type Cursor<'a>
+        = &'a [u8]
+    where
+        Self: 'a;
+
+    fn cursor(&self, index: usize) -> Self::Cursor<'_> {
+        &self[index..]
+    }
+}
+
+impl Cursor for VecDeque<u8> {
+    type Cursor<'a>
+        = Chain<&'a [u8], &'a [u8]>
+    where
+        Self: 'a;
+
+    fn cursor(&self, index: usize) -> Self::Cursor<'_> {
+        let (s1, s2) = self.as_slices();
+        let mut chain = s1.chain(s2);
+        chain.advance(index);
+        chain
+    }
+}

--- a/src/buf/cursor_mut.rs
+++ b/src/buf/cursor_mut.rs
@@ -1,0 +1,26 @@
+use crate::BufMut;
+
+/// # Safety
+///
+/// It must be safe to call Self::CursorMut::advance_mut. This should be true
+/// if the type Self::CursorMut does not allow to access bytes writen to it.
+/// For exemple, Vec<u8> is not ok, as the content written to it is accesible.
+/// On the other hand &mut [u8] is ok, as the content written cant't be accessed.
+pub unsafe trait CursorMut: BufMut {
+    type CursorMut<'a>: BufMut
+    where
+        Self: 'a;
+
+    fn cursor_mut(&mut self, index: usize) -> Self::CursorMut<'_>;
+}
+
+unsafe impl CursorMut for &mut [u8] {
+    type CursorMut<'a>
+        = &'a mut [u8]
+    where
+        Self: 'a;
+
+    fn cursor_mut(&mut self, index: usize) -> Self::CursorMut<'_> {
+        &mut self[index..]
+    }
+}

--- a/src/buf/limit.rs
+++ b/src/buf/limit.rs
@@ -1,5 +1,6 @@
 use crate::buf::UninitSlice;
 use crate::BufMut;
+use crate::CursorMut;
 
 use core::cmp;
 
@@ -71,5 +72,16 @@ unsafe impl<T: BufMut> BufMut for Limit<T> {
         assert!(cnt <= self.limit);
         self.inner.advance_mut(cnt);
         self.limit -= cnt;
+    }
+}
+
+unsafe impl<T: CursorMut> CursorMut for Limit<T> {
+    type CursorMut<'a>
+        = Limit<T::CursorMut<'a>>
+    where
+        Self: 'a;
+
+    fn cursor_mut(&mut self, index: usize) -> Self::CursorMut<'_> {
+        self.inner.cursor_mut(index).limit(self.limit - index)
     }
 }

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -17,6 +17,8 @@
 mod buf_impl;
 mod buf_mut;
 mod chain;
+mod cursor;
+mod cursor_mut;
 mod iter;
 mod limit;
 #[cfg(feature = "std")]
@@ -30,6 +32,8 @@ mod writer;
 pub use self::buf_impl::Buf;
 pub use self::buf_mut::BufMut;
 pub use self::chain::Chain;
+pub use self::cursor::Cursor;
+pub use self::cursor_mut::CursorMut;
 pub use self::iter::IntoIter;
 pub use self::limit::Limit;
 pub use self::take::Take;

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -1,4 +1,4 @@
-use crate::Buf;
+use crate::{Buf, Cursor};
 
 use core::cmp;
 
@@ -183,5 +183,16 @@ impl<T: Buf> Buf for Take<T> {
             }
         }
         cnt
+    }
+}
+
+impl<T: Cursor> Cursor for Take<T> {
+    type Cursor<'a>
+        = Take<T::Cursor<'a>>
+    where
+        Self: 'a;
+
+    fn cursor(&self, index: usize) -> Self::Cursor<'_> {
+        self.inner.cursor(index).take(self.limit - index)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod buf;
-pub use crate::buf::{Buf, BufMut};
+pub use crate::buf::{Buf, BufMut, Cursor, CursorMut};
 
 mod bytes;
 mod bytes_mut;


### PR DESCRIPTION
Has many others before, I've been looking for a way to read or write ahead, or seek into a `Buf` or a `BufMut` (see #823, #658, #382 to name a few)

While this PR might not solve everyone's problems, I has the benefit of not braking the API (it only adds 2 new traits) and simple (by relying as much as possible on the existing `Buf` and `BufMut`).

The simple solution to read ahead in a `Buf` I've seen proposed (like here https://github.com/tokio-rs/bytes/issues/382#issuecomment-605513824) is to clone the `Buf`. But making `T: Buf + Clone` your interface wont work in practice: it's fine if your `Buf` is a `&[u8]` but not if it's a `Vec<u8>`.

So the Idea is to add a trait (named Cursor for now) whit an associated type that is a cheap version of our `Buf`.
For example the Cursor of a `Vec<u8>` is a `&[u8]`, for a `Chain<Vec<u8>, Vec<u8>>` it's a `Chain<&[u8], &[u8]>` etc...

The Cursor trait allows you to get a cheap copy of you `Buf` that you can use to read ahead without mutating the original `Buf`.

This should also work for writing ahead to a `BufMut` before possibly committing what have been written by calling advance.

This PR is incomplete, lacks some implementation and tests, but I'm looking for feedback before finishing it.

Also I understand adding new features is complicated because any it's impossible to make breaking change. It should be possible to put this in it's own create depending on bytes. But again looking for some feedback.

Thanks !