### PR TITLE
Implement `From<Vec<u8>> for BytesMut`

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1366,6 +1366,12 @@ impl<'a> From<&'a str> for BytesMut {
     }
 }
 
+impl From<Vec<u8>> for BytesMut {
+    fn from(src: Vec<u8>) -> BytesMut {
+        BytesMut::from(Bytes::from(src))
+    }
+}
+
 impl From<BytesMut> for Bytes {
     fn from(src: BytesMut) -> Bytes {
         src.freeze()

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1368,7 +1368,7 @@ impl<'a> From<&'a str> for BytesMut {
 
 impl From<Vec<u8>> for BytesMut {
     fn from(src: Vec<u8>) -> BytesMut {
-        BytesMut::from(Bytes::from(src))
+        BytesMut::from_vec(src)
     }
 }
 


### PR DESCRIPTION
Working in a downstream dependency this would make some code a teeny bit nicer, and this is additionally the subject of #615. The implementation currently goes into `Bytes` first and then into `BytesMut`.

Closes #615