### PR TITLE
Specialize `BytesMut::extend<u8>` when its Vec-backed

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -1197,6 +1197,26 @@ impl BytesMut {
             slice::from_raw_parts_mut(ptr.cast(), len)
         }
     }
+
+    /// Extends the buffer from an `IntoIterator<Item = u8>`.
+    ///
+    /// # SAFETY
+    ///
+    /// The caller must ensure that `self.kind()` is `KIND_VEC`.
+    unsafe fn extend_vec<I: IntoIterator<Item = u8>>(&mut self, iter: I) {
+        debug_assert_eq!(self.kind(), KIND_VEC);
+
+        let off = self.get_vec_pos();
+        let vec = ManuallyDrop::new(rebuild_vec(self.ptr.as_ptr(), self.len, self.cap, off));
+
+        let mut guard = VecRebuildGuard {
+            bytes: self,
+            vec,
+            off,
+        };
+
+        guard.vec.extend(iter);
+    }
 }
 
 impl Drop for BytesMut {
@@ -1472,10 +1492,12 @@ impl Extend<u8> for BytesMut {
         let (lower, _) = iter.size_hint();
         self.reserve(lower);
 
-        // TODO: optimize
-        // 1. If self.kind() == KIND_VEC, use Vec::extend
-        for b in iter {
-            self.put_u8(b);
+        if self.kind() == KIND_VEC {
+            unsafe { self.extend_vec(iter) };
+        } else {
+            for b in iter {
+                self.put_u8(b);
+            }
         }
     }
 }
@@ -1866,6 +1888,26 @@ unsafe fn rebuild_vec(ptr: *mut u8, mut len: usize, mut cap: usize, off: usize) 
     cap += off;
 
     Vec::from_raw_parts(ptr, len, cap)
+}
+
+/// RAII guard in case the extension panics and is caught before
+/// we update the state.
+///
+/// On drop - updates the `BytesMut` len, cap and ptr.
+struct VecRebuildGuard<'a> {
+    bytes: &'a mut BytesMut,
+    vec: ManuallyDrop<Vec<u8>>,
+    off: usize,
+}
+
+impl Drop for VecRebuildGuard<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            self.bytes.len = self.vec.len() - self.off;
+            self.bytes.cap = self.vec.capacity() - self.off;
+            self.bytes.ptr = vptr(self.vec.as_mut_ptr().add(self.off));
+        }
+    }
 }
 
 // ===== impl SharedVtable =====

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -598,6 +598,63 @@ fn extend_mut() {
 }
 
 #[test]
+fn extend_mut_after_advance() {
+    let mut bytes = BytesMut::with_capacity(16);
+    bytes.extend_from_slice(b"abcdef");
+    bytes.advance(2);
+
+    bytes.extend([b'g', b'h']);
+
+    assert_eq!(bytes.len(), 6);
+    assert_eq!(&bytes[..], b"cdefgh");
+    assert_eq!(bytes.capacity(), 14);
+}
+
+#[test]
+#[cfg_attr(not(panic = "unwind"), ignore)]
+fn extend_mut_keeps_buffer_valid_on_iterator_panic() {
+    struct PanicAfter {
+        next: u8,
+        remaining: usize,
+    }
+
+    impl Iterator for PanicAfter {
+        type Item = u8;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.remaining == 0 {
+                panic!("test-triggered iterator panic");
+            }
+
+            let next = self.next;
+            self.next += 1;
+            self.remaining -= 1;
+            Some(next)
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (0, None)
+        }
+    }
+
+    let mut bytes = BytesMut::with_capacity(16);
+    bytes.extend_from_slice(b"a");
+
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        bytes.extend(PanicAfter {
+            next: b'b',
+            remaining: 3,
+        });
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(&bytes[..], b"abcd");
+
+    bytes.extend_from_slice(b"ef");
+    assert_eq!(&bytes[..], b"abcdef");
+}
+
+#[test]
 fn extend_from_slice_mut() {
     for &i in &[3, 34] {
         let mut bytes = BytesMut::new();


### PR DESCRIPTION
This PR adds a specialized code path to extending `BytesMut` when its backed by a `Vec`. There are no external changes, only a private function and type with some tests.

When benchmarking on my laptop (M3 Max MacBook Pro), the change to `put_slice_vec_extend` is from 480 MB/s to over 9000MB/s. Happy to bench on some Intel hardware if the data is interesting.



