### PR TITLE
Add BytesMut::try_shrink_to_fit and BytesMut::try_shrink_to_capacity

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -858,6 +858,60 @@ impl BytesMut {
         self.reserve_inner(additional, false)
     }
 
+    /// Attempts to shrink the buffer's capacity to fit its current length.
+    ///
+    /// This operation preserves the current contents and returns `true` when
+    /// the allocation is successfully shrunk. For `BytesMut` values backed by
+    /// shared storage, this only succeeds when the current handle is the only
+    /// remaining owner of the underlying allocation; otherwise it returns
+    /// `false` and leaves the buffer unchanged.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BytesMut;
+    ///
+    /// let mut buf = BytesMut::with_capacity(64);
+    /// buf.extend_from_slice(b"hello");
+    ///
+    /// assert!(buf.try_shrink_to_fit());
+    /// assert_eq!(buf.capacity(), 5);
+    /// assert_eq!(&buf[..], b"hello");
+    /// ```
+    pub fn try_shrink_to_fit(&mut self) -> bool {
+        let kind = self.kind();
+
+        if kind == KIND_VEC {
+            unsafe {
+                let off = self.get_vec_pos();
+                let v = rebuild_vec(self.ptr.as_ptr(), self.len, self.cap, off);
+                let mut v = ManuallyDrop::new(v);
+                v.shrink_to_fit();
+                self.ptr = vptr(v.as_mut_ptr().add(off));
+                self.cap = v.capacity() - off;
+            }
+            return true;
+        }
+
+        debug_assert_eq!(kind, KIND_ARC);
+        let shared: *mut Shared = self.data;
+
+        unsafe {
+            if (*shared).is_unique() {
+                let v = &mut (*shared).vec;
+                let v_ptr = v.as_mut_ptr();
+                let offset = self.ptr.as_ptr().offset_from(v_ptr) as usize;
+
+                v.shrink_to_fit();
+                self.ptr = vptr(v.as_mut_ptr().add(offset));
+                self.cap = v.capacity() - offset;
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// Appends given bytes to this `BytesMut`.
     ///
     /// If this `BytesMut` object does not have enough capacity, it is resized

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -886,13 +886,7 @@ impl BytesMut {
                 let off = self.get_vec_pos();
                 let v = rebuild_vec(self.ptr.as_ptr(), self.len, self.cap, off);
                 let mut v = ManuallyDrop::new(v);
-                // Offset views may point past bytes that are not part of this
-                // buffer. Move the live range to the start before shrinking.
-                if self.len != 0 {
-                    ptr::copy(self.ptr.as_ptr(), v.as_mut_ptr(), self.len);
-                }
-                v.set_len(self.len);
-                v.shrink_to_fit();
+                shrink_vec_to_fit(&mut v, self.ptr.as_ptr(), self.len);
                 self.ptr = vptr(v.as_mut_ptr());
                 self.cap = v.capacity();
                 self.set_vec_pos(0);
@@ -907,13 +901,7 @@ impl BytesMut {
             if (*shared).is_unique() {
                 let v = &mut (*shared).vec;
 
-                // Offset views may point past bytes that are not part of this
-                // buffer. Move the live range to the start before shrinking.
-                if self.len != 0 {
-                    ptr::copy(self.ptr.as_ptr(), v.as_mut_ptr(), self.len);
-                }
-                v.set_len(self.len);
-                v.shrink_to_fit();
+                shrink_vec_to_fit(v, self.ptr.as_ptr(), self.len);
                 self.ptr = vptr(v.as_mut_ptr());
                 self.cap = v.capacity();
                 return true;
@@ -1931,6 +1919,17 @@ unsafe fn rebuild_vec(ptr: *mut u8, mut len: usize, mut cap: usize, off: usize) 
     cap += off;
 
     Vec::from_raw_parts(ptr, len, cap)
+}
+
+// `ptr..ptr + len` must be initialized bytes within `vec`'s allocation.
+unsafe fn shrink_vec_to_fit(vec: &mut Vec<u8>, ptr: *mut u8, len: usize) {
+    // Offset views may point past bytes that are not part of this buffer. Move
+    // the live range to the start before shrinking.
+    if len != 0 {
+        ptr::copy(ptr, vec.as_mut_ptr(), len);
+    }
+    vec.set_len(len);
+    vec.shrink_to_fit();
 }
 
 // ===== impl SharedVtable =====

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -858,6 +858,60 @@ impl BytesMut {
         self.reserve_inner(additional, false)
     }
 
+    /// Attempts to shrink the buffer's capacity with a lower bound.
+    ///
+    /// The capacity will remain at least as large as both the length and the
+    /// supplied capacity. This operation preserves the current contents and
+    /// returns `true` when the allocation can be reclaimed. For `BytesMut`
+    /// values backed by shared storage, this only succeeds when the current
+    /// handle is the only remaining owner of the underlying allocation;
+    /// otherwise it returns `false` and leaves the buffer unchanged.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BytesMut;
+    ///
+    /// let mut buf = BytesMut::with_capacity(64);
+    /// buf.extend_from_slice(b"hello");
+    ///
+    /// assert!(buf.try_shrink_to_capacity(16));
+    /// assert_eq!(buf.capacity(), 16);
+    /// assert_eq!(&buf[..], b"hello");
+    /// ```
+    pub fn try_shrink_to_capacity(&mut self, capacity: usize) -> bool {
+        let kind = self.kind();
+
+        if kind == KIND_VEC {
+            unsafe {
+                let off = self.get_vec_pos();
+                let v = rebuild_vec(self.ptr.as_ptr(), self.len, self.cap, off);
+                let mut v = ManuallyDrop::new(v);
+                shrink_vec(&mut v, self.ptr.as_ptr(), self.len, capacity);
+                self.ptr = vptr(v.as_mut_ptr());
+                self.cap = v.capacity();
+                self.set_vec_pos(0);
+            }
+            return true;
+        }
+
+        debug_assert_eq!(kind, KIND_ARC);
+        let shared: *mut Shared = self.data;
+
+        unsafe {
+            if (*shared).is_unique() {
+                let v = &mut (*shared).vec;
+
+                shrink_vec(v, self.ptr.as_ptr(), self.len, capacity);
+                self.ptr = vptr(v.as_mut_ptr());
+                self.cap = v.capacity();
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// Attempts to shrink the buffer's capacity to fit its current length.
     ///
     /// This operation preserves the current contents and returns `true` when
@@ -879,36 +933,7 @@ impl BytesMut {
     /// assert_eq!(&buf[..], b"hello");
     /// ```
     pub fn try_shrink_to_fit(&mut self) -> bool {
-        let kind = self.kind();
-
-        if kind == KIND_VEC {
-            unsafe {
-                let off = self.get_vec_pos();
-                let v = rebuild_vec(self.ptr.as_ptr(), self.len, self.cap, off);
-                let mut v = ManuallyDrop::new(v);
-                shrink_vec_to_fit(&mut v, self.ptr.as_ptr(), self.len);
-                self.ptr = vptr(v.as_mut_ptr());
-                self.cap = v.capacity();
-                self.set_vec_pos(0);
-            }
-            return true;
-        }
-
-        debug_assert_eq!(kind, KIND_ARC);
-        let shared: *mut Shared = self.data;
-
-        unsafe {
-            if (*shared).is_unique() {
-                let v = &mut (*shared).vec;
-
-                shrink_vec_to_fit(v, self.ptr.as_ptr(), self.len);
-                self.ptr = vptr(v.as_mut_ptr());
-                self.cap = v.capacity();
-                return true;
-            }
-        }
-
-        false
+        self.try_shrink_to_capacity(self.len)
     }
 
     /// Appends given bytes to this `BytesMut`.
@@ -1922,14 +1947,14 @@ unsafe fn rebuild_vec(ptr: *mut u8, mut len: usize, mut cap: usize, off: usize) 
 }
 
 // `ptr..ptr + len` must be initialized bytes within `vec`'s allocation.
-unsafe fn shrink_vec_to_fit(vec: &mut Vec<u8>, ptr: *mut u8, len: usize) {
+unsafe fn shrink_vec(vec: &mut Vec<u8>, ptr: *mut u8, len: usize, capacity: usize) {
     // Offset views may point past bytes that are not part of this buffer. Move
     // the live range to the start before shrinking.
     if len != 0 {
         ptr::copy(ptr, vec.as_mut_ptr(), len);
     }
     vec.set_len(len);
-    vec.shrink_to_fit();
+    vec.shrink_to(capacity);
 }
 
 // ===== impl SharedVtable =====

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -886,9 +886,16 @@ impl BytesMut {
                 let off = self.get_vec_pos();
                 let v = rebuild_vec(self.ptr.as_ptr(), self.len, self.cap, off);
                 let mut v = ManuallyDrop::new(v);
+                // Offset views may point past bytes that are not part of this
+                // buffer. Move the live range to the start before shrinking.
+                if self.len != 0 {
+                    ptr::copy(self.ptr.as_ptr(), v.as_mut_ptr(), self.len);
+                }
+                v.set_len(self.len);
                 v.shrink_to_fit();
-                self.ptr = vptr(v.as_mut_ptr().add(off));
-                self.cap = v.capacity() - off;
+                self.ptr = vptr(v.as_mut_ptr());
+                self.cap = v.capacity();
+                self.set_vec_pos(0);
             }
             return true;
         }
@@ -899,12 +906,16 @@ impl BytesMut {
         unsafe {
             if (*shared).is_unique() {
                 let v = &mut (*shared).vec;
-                let v_ptr = v.as_mut_ptr();
-                let offset = self.ptr.as_ptr().offset_from(v_ptr) as usize;
 
+                // Offset views may point past bytes that are not part of this
+                // buffer. Move the live range to the start before shrinking.
+                if self.len != 0 {
+                    ptr::copy(self.ptr.as_ptr(), v.as_mut_ptr(), self.len);
+                }
+                v.set_len(self.len);
                 v.shrink_to_fit();
-                self.ptr = vptr(v.as_mut_ptr().add(offset));
-                self.cap = v.capacity() - offset;
+                self.ptr = vptr(v.as_mut_ptr());
+                self.cap = v.capacity();
                 return true;
             }
         }

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -400,3 +400,53 @@ fn test_bytes_mut_try_shrink_to_fit_cant_shrink_with_bytes_ref() {
     assert_eq!(&buf[..], b"abc");
     assert_eq!(&bytes[..], b"def");
 }
+
+#[test]
+fn test_bytes_mut_try_shrink_to_capacity() {
+    let mut buf = BytesMut::with_capacity(64);
+    buf.extend_from_slice(b"hello");
+
+    assert!(buf.try_shrink_to_capacity(16));
+    assert_eq!(buf.capacity(), 16);
+    assert_eq!(&buf[..], b"hello");
+}
+
+#[test]
+fn test_bytes_mut_try_shrink_to_capacity_does_not_shrink_below_len() {
+    let mut buf = BytesMut::with_capacity(64);
+    buf.extend_from_slice(b"hello world");
+
+    assert!(buf.try_shrink_to_capacity(5));
+    assert_eq!(buf.capacity(), buf.len());
+    assert_eq!(buf.capacity(), 11);
+    assert_eq!(&buf[..], b"hello world");
+}
+
+#[test]
+fn test_bytes_mut_try_shrink_to_capacity_after_advance() {
+    let mut buf = BytesMut::with_capacity(64);
+    buf.extend_from_slice(b"hello world");
+    buf.advance(6);
+
+    assert!(buf.try_shrink_to_capacity(16));
+    assert_eq!(buf.capacity(), 16);
+    assert_eq!(&buf[..], b"world");
+}
+
+#[test]
+fn test_bytes_mut_try_shrink_to_capacity_cant_shrink_with_refs() {
+    let mut buf = BytesMut::from(&b"abcdef"[..]);
+    buf.reserve(8);
+
+    let mut other = buf.split_off(3);
+    let buf_cap = buf.capacity();
+    let other_cap = other.capacity();
+
+    assert!(!buf.try_shrink_to_capacity(4));
+    assert_eq!(buf.capacity(), buf_cap);
+    assert_eq!(&buf[..], b"abc");
+
+    assert!(!other.try_shrink_to_capacity(4));
+    assert_eq!(other.capacity(), other_cap);
+    assert_eq!(&other[..], b"def");
+}

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 
 use bytes::buf::UninitSlice;
-use bytes::{BufMut, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 use core::fmt::Write;
 use core::mem::MaybeUninit;
 
@@ -308,14 +308,14 @@ fn test_bytes_mut_try_shrink_to_fit_cant_shrink_with_refs() {
 
     let mut other = buf.split_off(2);
 
-    assert_eq!(buf.try_shrink_to_fit(), false, "if there are other references to the buffer, it can't be safely shrunk");
-    assert_eq!(buf.capacity(), 2, "the capacity of the original buffer shrinks to the length of the buffer when there are other references to it");
-    assert_eq!(&buf[..], b"ab", "the original buffer should still contain the first two bytes");
+    assert!(!buf.try_shrink_to_fit());
+    assert_eq!(buf.capacity(), 2);
+    assert_eq!(&buf[..], b"ab");
 
-    assert_eq!(other.try_shrink_to_fit(), false, "the other buffer can be shrunk to fit");
-    assert_eq!(other.capacity(), 6, "the other buffer's capacity should be 6");
-    assert_eq!(other.len(), 1, "the other buffer's length should be 1");
-    assert_eq!(&other[..], b"c", "the other buffer should contain the last byte");
+    assert!(!other.try_shrink_to_fit());
+    assert_eq!(other.capacity(), 6);
+    assert_eq!(other.len(), 1);
+    assert_eq!(&other[..], b"c");
 }
 
 #[test]
@@ -323,17 +323,80 @@ fn test_bytes_mut_try_shrink_to_fit_after_split_off() {
     let data = b"hello world";
     let mut buf = BytesMut::with_capacity(64);
 
-    assert_eq!(buf.capacity(), 64, "buf capacity should be 64 before extending");
+    assert_eq!(buf.capacity(), 64);
     buf.extend_from_slice(data);
-    assert_eq!(buf.capacity(), 64, "buf capacity should be 64 after extending");
+    assert_eq!(buf.capacity(), 64);
 
     let mut other = buf.split_off(5);
-    assert_eq!(&buf[..], b"hello", "buf should contain the first half of the data");
-    assert_eq!(&other[..], b" world", "other should contain the second half of the data");
-    assert_eq!(buf.capacity(), 5, "buf capacity should be 5 after splitting");
-    assert_eq!(other.capacity(), 59, "other capacity should be 59 before shrinking");
+    assert_eq!(&buf[..], b"hello");
+    assert_eq!(&other[..], b" world");
+    assert_eq!(buf.capacity(), 5);
+    assert_eq!(other.capacity(), 59);
 
     drop(buf);
     assert!(other.try_shrink_to_fit());
-    assert_eq!(other.capacity(), 6, "other capacity should be 6 after shrinking");
+    assert_eq!(other.capacity(), 6);
+}
+
+#[test]
+fn test_bytes_mut_try_shrink_to_fit_unique_front_after_split_off() {
+    let mut buf = BytesMut::with_capacity(64);
+    buf.extend_from_slice(b"hello world");
+
+    let other = buf.split_off(5);
+    drop(other);
+
+    assert!(buf.try_shrink_to_fit());
+    assert_eq!(buf.capacity(), buf.len());
+    assert_eq!(buf.capacity(), 5);
+    assert_eq!(&buf[..], b"hello");
+}
+
+#[test]
+fn test_bytes_mut_try_shrink_to_fit_unique_empty_tail_past_len() {
+    let mut buf = BytesMut::with_capacity(64);
+    buf.extend_from_slice(b"abc");
+
+    let mut other = buf.split_off(10);
+    drop(buf);
+
+    assert!(other.try_shrink_to_fit());
+    assert!(other.is_empty());
+    assert_eq!(other.capacity(), 0);
+}
+
+#[test]
+fn test_bytes_mut_try_shrink_to_fit_after_advance() {
+    let mut buf = BytesMut::with_capacity(64);
+    buf.extend_from_slice(b"hello world");
+    buf.advance(6);
+
+    assert!(buf.try_shrink_to_fit());
+    assert_eq!(buf.capacity(), buf.len());
+    assert_eq!(buf.capacity(), 5);
+    assert_eq!(&buf[..], b"world");
+}
+
+#[test]
+fn test_bytes_mut_try_shrink_to_fit_empty_after_advance() {
+    let mut buf = BytesMut::with_capacity(64);
+    buf.extend_from_slice(b"abc");
+    buf.advance(3);
+
+    assert!(buf.try_shrink_to_fit());
+    assert!(buf.is_empty());
+    assert_eq!(buf.capacity(), 0);
+}
+
+#[test]
+fn test_bytes_mut_try_shrink_to_fit_cant_shrink_with_bytes_ref() {
+    let mut buf = BytesMut::from(&b"abcdef"[..]);
+    buf.reserve(8);
+
+    let bytes = buf.split_off(3).freeze();
+
+    assert!(!buf.try_shrink_to_fit());
+    assert_eq!(buf.capacity(), 3);
+    assert_eq!(&buf[..], b"abc");
+    assert_eq!(&bytes[..], b"def");
 }

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -282,3 +282,58 @@ fn test_bytes_mut_reuse() {
     let mut buf = BytesMut::new();
     buf.put(&[1u8, 2, 3] as &[u8]);
 }
+
+#[test]
+fn test_bytes_mut_try_shrink_to_fit_empty() {
+    let mut buf = BytesMut::new();
+
+    assert!(buf.try_shrink_to_fit());
+    assert!(buf.is_empty());
+    assert_eq!(buf.capacity(), 0);
+}
+
+#[test]
+fn test_bytes_mut_try_shrink_to_fit_already_tight() {
+    let mut buf = BytesMut::from(&b"abc"[..]);
+
+    assert!(buf.try_shrink_to_fit());
+    assert_eq!(buf.capacity(), buf.len());
+    assert_eq!(&buf[..], b"abc");
+}
+
+#[test]
+fn test_bytes_mut_try_shrink_to_fit_cant_shrink_with_refs() {
+    let mut buf = BytesMut::from(&b"abc"[..]);
+    buf.reserve(3);
+
+    let mut other = buf.split_off(2);
+
+    assert_eq!(buf.try_shrink_to_fit(), false, "if there are other references to the buffer, it can't be safely shrunk");
+    assert_eq!(buf.capacity(), 2, "the capacity of the original buffer shrinks to the length of the buffer when there are other references to it");
+    assert_eq!(&buf[..], b"ab", "the original buffer should still contain the first two bytes");
+
+    assert_eq!(other.try_shrink_to_fit(), false, "the other buffer can be shrunk to fit");
+    assert_eq!(other.capacity(), 6, "the other buffer's capacity should be 6");
+    assert_eq!(other.len(), 1, "the other buffer's length should be 1");
+    assert_eq!(&other[..], b"c", "the other buffer should contain the last byte");
+}
+
+#[test]
+fn test_bytes_mut_try_shrink_to_fit_after_split_off() {
+    let data = b"hello world";
+    let mut buf = BytesMut::with_capacity(64);
+
+    assert_eq!(buf.capacity(), 64, "buf capacity should be 64 before extending");
+    buf.extend_from_slice(data);
+    assert_eq!(buf.capacity(), 64, "buf capacity should be 64 after extending");
+
+    let mut other = buf.split_off(5);
+    assert_eq!(&buf[..], b"hello", "buf should contain the first half of the data");
+    assert_eq!(&other[..], b" world", "other should contain the second half of the data");
+    assert_eq!(buf.capacity(), 5, "buf capacity should be 5 after splitting");
+    assert_eq!(other.capacity(), 59, "other capacity should be 59 before shrinking");
+
+    drop(buf);
+    assert!(other.try_shrink_to_fit());
+    assert_eq!(other.capacity(), 6, "other capacity should be 6 after shrinking");
+}


### PR DESCRIPTION
Fixes `BytesMut::try_shrink_to_fit` when the `BytesMut` is an offset view into its backing allocation.

Previously, the implementation called `Vec::shrink_to_fit` while preserving the current offset into the allocation. That caused incorrect behavior for split/advanced buffers, including:

- returning `true` while leaving capacity larger than the current length
- panicking from capacity underflow when a split tail started past the initialized length

The fix normalizes the live byte range to the start of the backing `Vec` before shrinking, then updates the handle to point at the new base allocation.

## Tests

Added coverage for:

- shrinking the tail after `split_off`
- shrinking the front after dropping the split tail
- split tails that start past the initialized length
- vec-backed offset views after `advance`
- empty vec-backed offset views
- outstanding `BytesMut` and frozen `Bytes` references

Validated with:

```sh
cargo test try_shrink_to -- --nocapture
cargo test
cargo +nightly miri test try_shrink_to
```

## Why
While using `tokio-postgres` with `deadpool`, we noticed increased memory usage from buffer allocations in these libraries. These buffers are pre-allocated when a connection is created and live until that connection is closed.

For applications with only a few connections, or with consistently small result sets, this usually is not a problem. However, applications with many long-lived connections can accumulate a large amount of retained buffer capacity. If some of those connections occasionally handle large reads or writes, the associated `BytesMut` buffers can remain inflated for the rest of the connection lifetime, leading to significant memory overuse, sometimes multiple gigabytes depending on the application.

Adding `try_shrink_to_fit` and `try_shrink_to_capacity` instead of creating a new BytesMut for each request/response ideal over adding potentially significant churn in downstream codebases.

References:
- https://github.com/rust-postgres/rust-postgres/issues/1081
- https://github.com/deadpool-rs/deadpool/pull/273
- https://github.com/linkerd/linkerd2/issues/11012
- https://github.com/actix/actix-web/issues/1780
- https://github.com/tokio-rs/bytes/issues/634