### PR TITLE
Release bytes v1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.12.1 (July 7th, 2026)
+# 1.12.1 (July 8th, 2026)
 
 ### Fixed
 - Properly handle when `Box::new` panics (#837)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.12.1 (July 7th, 2026)
+
+### Fixed
+- Properly handle when `Box::new` panics (#837)
+
 # 1.12.0 (June 18th, 2026)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bytes"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.12.0"
+version = "1.12.1"
 edition = "2021"
 rust-version = "1.57"
 license = "MIT"


### PR DESCRIPTION
# 1.12.1 (July 8th, 2026)

### Fixed
- Properly handle when `Box::new` panics (#837)