### PR TITLE
fix: try_get_int/try_get_int_le do not sign-extend n-byte integers

### DIFF
--- a/src/buf/buf_impl.rs
+++ b/src/buf/buf_impl.rs
@@ -2084,7 +2084,7 @@ pub trait Buf {
     ///
     /// This function panics if `nbytes` is greater than 8.
     fn try_get_int(&mut self, nbytes: usize) -> Result<i64, TryGetError> {
-        buf_try_get_impl!(be => self, i64, nbytes);
+        Ok(sign_extend(self.try_get_uint(nbytes)?, nbytes))
     }
 
     /// Gets a signed n-byte integer from `self` in little-endian byte order.
@@ -2116,7 +2116,7 @@ pub trait Buf {
     ///
     /// This function panics if `nbytes` is greater than 8.
     fn try_get_int_le(&mut self, nbytes: usize) -> Result<i64, TryGetError> {
-        buf_try_get_impl!(le => self, i64, nbytes);
+        Ok(sign_extend(self.try_get_uint_le(nbytes)?, nbytes))
     }
 
     /// Gets a signed n-byte integer from `self` in native-endian byte order.

--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -459,3 +459,35 @@ fn copy_to_bytes_mut() {
     let bytes_mut2 = BytesMut::from(ret);
     assert_eq!(bytes_mut2.as_ptr(), ptr);
 }
+
+#[test]
+fn try_get_int_sign_extends() {
+    use ::bytes::TryGetError;
+    // 3-byte big-endian 0xffffff == -1; must match get_int
+    let mut a = &[0xff, 0xff, 0xff][..];
+    assert_eq!(a.try_get_int(3), Ok(-1));
+    assert_eq!(a.remaining(), 0);
+    let mut ctrl = &[0xff, 0xff, 0xff][..];
+    assert_eq!(ctrl.get_int(3), -1);
+    // little-endian variant
+    let mut le = &[0xff, 0xff, 0xff][..];
+    assert_eq!(le.try_get_int_le(3), Ok(-1));
+    // native-endian delegates
+    let mut ne = &[0xff, 0xff, 0xff][..];
+    assert_eq!(ne.try_get_int_ne(3), Ok(-1));
+    // positive value unchanged
+    let mut pos = &[0x01, 0x02, 0x03][..];
+    assert_eq!(pos.try_get_int(3), Ok(0x010203));
+    // full width
+    let mut full = &[0xff; 8][..];
+    assert_eq!(full.try_get_int(8), Ok(-1));
+    // insufficient data still errors with the documented shape
+    let mut short = &[0x01, 0x02, 0x03][..];
+    assert_eq!(
+        short.try_get_int(4),
+        Err(TryGetError {
+            requested: 4,
+            available: 3
+        })
+    );
+}


### PR DESCRIPTION
## What

`Buf::try_get_int` and `Buf::try_get_int_le` now sign-extend the value they read for `nbytes < 8`, matching the behavior of the panicking `Buf::get_int` / `Buf::get_int_le`.

## Why

The panicking getters sign-extend via `sign_extend(self.get_uint(nbytes), nbytes)`. Their fallible twins instead used `buf_try_get_impl!`, which copies the bytes into the low bytes of a zeroed `[0u8; 8]` and calls `i64::from_{be,le}_bytes`. For `nbytes < 8` the high bytes stay zero, so no sign extension happens and a negative value is returned as a wrong positive number.

For example, the 3-byte big-endian value `0xffffff` (which `get_int(3)` returns as `-1`) was returned by `try_get_int(3)` as `16777215`.

`try_get_int_ne` delegates to these two methods and inherited the bug; it is fixed transitively. No `Buf` implementation overrides these methods, so all implementors were affected.

The fix makes the fallible getters mirror their panicking counterparts:

```rust
fn try_get_int(&mut self, nbytes: usize) -> Result<i64, TryGetError> {
    Ok(sign_extend(self.try_get_uint(nbytes)?, nbytes))
}
fn try_get_int_le(&mut self, nbytes: usize) -> Result<i64, TryGetError> {
    Ok(sign_extend(self.try_get_uint_le(nbytes)?, nbytes))
}
```

Edge cases are preserved: `nbytes > 8` still panics via `try_get_uint`'s documented check, `nbytes == 8` is an identity shift, and insufficient data still returns the same `Err(TryGetError { requested, available })` as before (existing doctests unchanged).

## Testing

- Added `try_get_int_sign_extends` to `tests/test_buf.rs`, covering big/little/native-endian sign extension, a positive value, full width, and the insufficient-data error shape. It fails on `master` (`try_get_int(3)` returns `Ok(16777215)`) and passes with this change.
- `cargo test` passes all suites and doctests, including the existing `try_get_int`/`try_get_int_le` doctests.
- `cargo fmt --all --check` is clean.
