### PR TITLE
refactor(bytes): clarify shared alignment assertions

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1348,7 +1348,12 @@ impl Drop for Shared {
 // This is a necessary invariant since we depend on allocating `Shared` a
 // shared object to implicitly carry the `KIND_ARC` flag in its pointer.
 // This flag is set when the LSB is 0.
-const _: [(); 0 - mem::align_of::<Shared>() % 2] = []; // Assert that the alignment of `Shared` is divisible by 2.
+const _: () = {
+    assert!(
+        mem::align_of::<Shared>() % 2 == 0,
+        "Shared alignment must be divisible by 2 for pointer tagging"
+    );
+};
 
 static SHARED_VTABLE: Vtable = Vtable {
     clone: shared_clone,

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -92,7 +92,12 @@ impl Shared {
 // This is a necessary invariant since we depend on allocating `Shared` a
 // shared object to implicitly carry the `KIND_ARC` flag in its pointer.
 // This flag is set when the LSB is 0.
-const _: [(); 0 - mem::align_of::<Shared>() % 2] = []; // Assert that the alignment of `Shared` is divisible by 2.
+const _: () = {
+    assert!(
+        mem::align_of::<Shared>() % 2 == 0,
+        "Shared alignment must be divisible by 2 for pointer tagging"
+    );
+};
 
 // Buffer storage strategy flags.
 const KIND_ARC: usize = 0b0;


### PR DESCRIPTION
## Summary

  This PR replaces the array-underflow-based compile-time checks:

  ```rust
  const _: [(); 0 - mem::align_of::<Shared>() % 2] = [];
```

  with explicit const assertions:
```
  const _: () = {
      assert!(
          mem::align_of::<Shared>() % 2 == 0,
          "Shared alignment must be divisible by 2 for pointer tagging"
      );
  };
```

  This change is neither a bug fix nor a new feature. It preserves the
  existing behavior and alignment invariant, while expressing that invariant
  in a more direct and readable form.

  ## Motivation

  The current array-length expression works, but it is not particularly
  beginner-friendly. A reader must work out that an odd alignment makes
  mem::align_of::<Shared>() % 2 equal to 1, which then causes 0 - 1 to
  fail during const evaluation.

  Using assert! states the requirement directly and also provides a clearer
  diagnostic if the invariant is ever violated.

  ## MSRV compatibility

  Using assert! in a const context is supported starting with Rust 1.57,
  as part of the stabilization of [panic! in const
  [contexts](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0/#panic-in-const-contexts) (https://blog.rust-lang.org/2021/12/02/Rust-1.57.0/#panic-in-const-contexts).

  The bytes crate already declares Rust 1.57 as its
  [MSRV](https://github.com/tokio-rs/bytes/blob/master/Cargo.toml#L9) (https://github.com/tokio-rs/bytes/blob/master/Cargo.toml#L9), so this
  change does not raise the minimum supported Rust version.

  ## Validation

  - cargo fmt --all -- --check
  - cargo check
  - cargo check --no-default-features
  - cargo test

  This is intentionally a small readability-only change. If the maintainers
  consider it unnecessary or prefer the existing idiom, please feel free to
  close this PR.