### PR TITLE
bytes: add try_unwrap_or_clone method to Bytes for zero-alloc unwrap fast-path

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -625,6 +625,28 @@ impl Bytes {
         }
     }
 
+    /// Consumes `self` and returns a `BytesMut`.
+    ///
+    /// If `self` is unique for the entire original buffer, this will return a `BytesMut`
+    /// referencing the same memory buffer without allocating. Otherwise, it will clone
+    /// the underlying contents into a new `BytesMut`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::{Bytes, BytesMut};
+    ///
+    /// let bytes = Bytes::from(b"hello".to_vec());
+    /// let mut_bytes = bytes.try_unwrap_or_clone();
+    /// assert_eq!(&mut_bytes[..], b"hello");
+    /// ```
+    pub fn try_unwrap_or_clone(self) -> BytesMut {
+        match self.try_into_mut() {
+            Ok(bm) => bm,
+            Err(b) => BytesMut::from(&b[..]),
+        }
+    }
+
     #[inline]
     pub(crate) unsafe fn with_vtable(
         ptr: *const u8,


### PR DESCRIPTION
### Summary
This PR adds `try_unwrap_or_clone(self) -> BytesMut` to `Bytes` in `src/bytes.rs`.

### Rationale & Performance Benefit
When converting a `Bytes` handle back into a mutable `BytesMut` buffer, `try_into_mut()` returns an `Err(Bytes)` if the handle is not unique. Callers currently have to manually match on `Ok` / `Err` and perform slice cloning.

Adding `try_unwrap_or_clone`:
- Provides a clean zero-allocation fast-path when the `Bytes` handle is unique.
- Clones underlying bytes into a new `BytesMut` buffer only when shared.
- Streamlines buffer conversion pipelines in high-throughput network applications.